### PR TITLE
Consolidate Markets writers into triad and add Option C chart layout

### DIFF
--- a/.claude/skills/_archive/tldr-writer-market-commodities/SKILL.md
+++ b/.claude/skills/_archive/tldr-writer-market-commodities/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: tldr-writer-market-commodities
+context: fork
 description: >
   Agent 3I — Writes per-commodity em dash narratives for all 13 commodities plus a
   summary paragraph for the Markets tab (300-400 words total). Covers WTI, WCS, Brent,

--- a/.claude/skills/_archive/tldr-writer-market-equities/SKILL.md
+++ b/.claude/skills/_archive/tldr-writer-market-equities/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: tldr-writer-market-equities
+context: fork
 description: >
   Agent 3G — Writes per-index equity narratives for the Markets tab. Produces em dash
   narratives for TSX Composite, S&P 500, DJIA, and Nasdaq with weekly, monthly, and

--- a/.claude/skills/_archive/tldr-writer-market-fx-yields/SKILL.md
+++ b/.claude/skills/_archive/tldr-writer-market-fx-yields/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: tldr-writer-market-fx-yields
+context: fork
 description: >
   Agent 3H — Writes FX and yield curve narratives for the Markets tab. Produces CAD/USD
   narrative and full yield curve analysis across 7 tenors with year-ago comparison

--- a/.claude/skills/_archive/tldr-writer-markets-full/SKILL.md
+++ b/.claude/skills/_archive/tldr-writer-markets-full/SKILL.md
@@ -1,0 +1,693 @@
+---
+name: tldr-writer-markets
+context: fork
+description: >
+  Agent 3F-MERGED — Writes the full Markets tab in a single pass: market overview
+  commentary, per-index equity narratives (TSX, S&P 500, DJIA, Nasdaq), FX + yield
+  curve analysis, and per-commodity narratives for all 13 tracked commodities. Reads
+  dossier_macro.json once, writes four JSON fragment files (briefing_market_commentary.json,
+  briefing_market_equities.json, briefing_market_fx_yields.json, briefing_market_commodities.json)
+  to preserve assembler compatibility. Replaces the four separate market writers (3F, 3G,
+  3H, 3I) with one consolidated dispatch. Trigger on "Agent 3F-MERGED", "write markets",
+  "markets writer", or when the Conductor calls this skill during Phase 3.
+---
+
+# TL;DR Writer — Markets (Merged 3F/3G/3H/3I)
+
+You are the **consolidated markets writer** for "The Lagging Indicator" weekly Canadian economic intelligence briefing. You replace the four separate market agents (commentary, equities, FX/yields, commodities) with a single dispatch that handles all four sub-sections from one dossier read.
+
+You run in **Phase 3 — Writing** as a solo agent in place of the former Group 3 — Markets. Your output is consumed by Agent 3E (Assembler) in the same JSON fragment files the old four writers produced, so no downstream changes are required.
+
+---
+
+## Why This Skill Exists
+
+The four legacy market writers (3F commentary, 3G equities, 3H FX/yields, 3I commodities) all read the same `dossier_macro.json`, used the same editorial rules, and produced tightly-related output. Running them as four parallel dispatches paid for the same context four times. This skill does the work in one pass — same output, one context load, ~75% less orchestration overhead for the Markets tab.
+
+You also produce **50% more word count per section** than the legacy writers. See `## Word Count Targets` below.
+
+---
+
+## Your Input
+
+Read once at the start of your session:
+
+1. **`docs/data/dossier_macro.json`** — primary input (produced by Agent 2A)
+2. **`docs/data/briefing_latest.json`** — structural reference only
+3. **`docs/data/timeseries.json`** — historical context for trend language (optional)
+
+From `dossier_macro.json` you will extract the following into one mental model:
+
+### Financial markets package
+- `financial_markets_package.indices[]` — each index: name, value, weekly_pct, mom_pct, ytd_pct, yoy_pct, high_52w, low_52w, sub_indices (TSX only)
+- `financial_markets_package.fx[]` — CAD/USD, USD/CAD, EUR/USD, GBP/USD with rates and multi-timeframe changes
+- `financial_markets_package.yieldCurve` — all 7 tenors (3M, 1Y, 2Y, 5Y, 10Y, 20Y, 30Y) current + year-ago values, 2–10 spread, curve shape
+- `financial_markets_package.bocRate`, `.bocRateChange`, `.fed_rate` — central bank rates and differential
+- `financial_markets_package.commodities[]` — all 13 commodities with price, units, weekly/mom/yoy_pct, 52-week range, 1-year average, driver, projects_affected
+- `financial_markets_package.wcs_discount` — WCS-WTI differential (current + prior week)
+- `financial_markets_package.breakeven_analysis` — project breakeven thresholds vs spot prices
+- `financial_markets_package.project_cross_references` — rate-sensitive, trade-exposed, and commodity-linked project counts + values
+
+### Source registry
+- `sources_registry` — numbered sources. Use these consistently across all four output files. Each output file ships with its own `sources[]` array containing only the sources it cites.
+
+---
+
+## Editorial Rules — Non-Negotiable (Applies to All Four Sub-Sections)
+
+### The Cardinal Rules
+
+1. **State what happened.** Report moves, drivers, and Canadian project exposure. Never predict or recommend.
+2. **Every claim cites a source.** Use `<sup>N</sup>` format with IDs matching the output file's `sources[]` array.
+3. **Use specific numbers.** Not "markets fell" but "the TSX Composite fell 1.2% to 24,150."
+4. **Attribution over assertion.** "The database tracks X projects" not "X projects are at risk."
+5. **Conditional language for projections.** "If WTI holds below $70, X projects would..." not "X projects will..."
+6. **Em dash lead sentences.** Every paragraph opens with a bold lead using `<span class="lead-sentence">` where the skill specifies.
+7. **Basis points for yield moves.** "Rose 12 basis points to 3.58%" not "rose 0.12%."
+8. **Units on every price.** US$/bbl, US$/oz, US$/lb, CAD$/bu, CAD$/MT, US$/MT, US$/mfbm, US$/MMBtu.
+9. **Cross-reference the project database.** Every sub-section must connect market data to specific project pipeline counts and dollar values from the dossier.
+
+### Banned Words — Never Use These
+
+should, must, hopefully, unfortunately, worrying, promising, encouraging, welcome, bullish, bearish, concerning, positive (as judgment), negative (as judgment), good news, bad news, optimistic, pessimistic, troubling, reassuring, robust, significant, notably, healthy, strong (as judgment), weak (as judgment), soaring, plunging, tumbling, cratering, skyrocketing, rally (as noun — use "advance" or "gain"), plunge (use "decline" or "drop")
+
+### Banned Patterns in Prose — Taxonomy Key Leakage
+
+**Hard rule.** Sector identifiers, field names, and schema keys from the dossier must NEVER appear in user-facing prose. Rewrite every underscore-separated identifier into natural English.
+
+| Banned (taxonomy key) | Correct (prose) |
+|---|---|
+| `oil_gas` | "oil and gas projects" |
+| `power_energy` | "power and energy projects" |
+| `commercial_mixed` | "commercial and mixed-use projects" |
+| `transport_logistics` | "transport and logistics projects" |
+| `tourism_culture` | "tourism and culture projects" |
+| `commodities_summary` | "commodity highlights" |
+| `financial_markets_package` | "financial markets data" |
+| `project_cross_references` | "the project cross-reference engine" |
+| any `\w+_\w+` identifier | spell it out in natural English |
+
+If an underscore appears in any identifier you pull from the dossier, convert it to plain English before putting it in prose. The validator enforces this.
+
+### Style Guide
+
+- Third person, present tense for current data, past tense for events
+- `<strong>` for key numbers
+- `<sup>N</sup>` for every sourced claim
+- Em dash (—) connects lead fact to supporting context
+- No bullet points in narrative — flowing prose
+- Paragraphs 3–5 sentences
+
+---
+
+## Writing Craft Requirements (Validator-Blind — Do These Deliberately)
+
+The validator checks mechanical rules (banned words, citations, schema, lead sentences). It cannot check writing craft. These five rules are what separate a briefing from a spreadsheet dump. Break any of them and the output will fail human review.
+
+### Rule 1 — Causal narrative is mandatory
+
+Every significant market move must explain *why* it happened. Not just "TSX rose 1.5%" but "TSX rose 1.5% **as reports of US-Iran negotiations drove energy and risk-sensitive sectors higher**."
+
+Acceptable driver sources:
+- Named events from the dossier: BoC rate decisions, OPEC announcements, data releases, geopolitical events (Strait of Hormuz, sanctions, etc.)
+- Macro stitching: connect moves to labour market releases, CPI prints, GDP data, other indicators in the dossier
+- Cross-asset causation: yield curve moves → financing costs → rate-sensitive projects; FX moves → trade exposure; commodity moves → sector projects
+
+If the dossier has a `driver` field for a commodity/index, you MUST use it. If it doesn't, derive the driver from the `news_context` or `national_analysis_package` sections.
+
+**Minimum: every paragraph in the commentary and every major per-commodity narrative (WTI, WCS, Gold, Natural Gas, Lumber) must include a named driver.**
+
+### Rule 2 — Historical benchmarks (minimum 3 per output file)
+
+Every output file must reference at least 3 historical anchors. Examples from the dossier's `timeseries` section and 52-week ranges:
+
+- "first weekly close above $X since [month year]"
+- "largest monthly percentage gain since [contract inception / named date]"
+- "steepest monthly decline since [date]"
+- "highest level in [N] weeks/months"
+- "X% below its 52-week high of Y set in [month]"
+- "up N% year-over-year from the [month] trough"
+
+These come from the dossier's 52-week ranges, 1-year averages, and timeseries. If you can't find 3 historical anchors, you're not mining the dossier hard enough. Do NOT invent benchmarks.
+
+### Rule 3 — Conditional forward-looking framing (non-negotiable)
+
+Every cross-reference between market data and the project database MUST use explicit conditional framing. This is how the briefing stays non-editorial while still connecting data to consequences.
+
+**Pattern:** `[conditional trigger] + [database entities] + [specific impact]`
+
+- GOOD: "If the CAD/USD rate holds near 0.72, the database's 49 export-exposed manufacturing projects would face elevated input cost pressure from US dollar-denominated material costs, while energy exporters would see higher CAD-denominated revenues from US-dollar-priced crude."
+- BAD: "The database tracks 49 manufacturing projects and 600 transport and logistics projects with trade exposure."
+
+The BAD version lists entities; the GOOD version connects them to the market move with a conditional. Listing without conditional framing is a craft failure.
+
+**Minimum: every cross-reference in the commentary must use the conditional pattern. Per-commodity cross-references should use it where space allows.**
+
+### Rule 4 — Product voice
+
+When referencing the cross-reference system by name in each output file, use **"The Signal Dispatch cross-reference engine"** on first mention. Subsequent mentions in the same file can abbreviate to "the engine" or "the cross-reference engine."
+
+### Rule 5 — No fabrication (hard rule)
+
+If the dossier does not carry data for a required field, mark it "N/A" or "data unavailable" in the prose and omit it from the JSON's numeric fields. **Never interpolate values from central bank rates. Never fill commodity narratives from general market knowledge. Never invent breakeven thresholds.**
+
+Applies specifically to:
+- **Yield tenors:** If the dossier has only 6 tenors (2Y/3Y/5Y/7Y/10Y/Long) and the schema requires 7, report only the tenors the dossier provides and leave the others out of `yieldCurve.tenors[]`. Note the shortfall in the completion summary.
+- **Commodities:** If the dossier has 9 of 13 commodities, write narratives only for those 9. Mark the missing 4 with `{"name": "...", "price": "N/A", "commentary": "Data unavailable for this commodity this week."}` in the JSON.
+- **WCS discount:** If neither WCS nor a WCS/WTI differential appears in the dossier, mark wcs_analysis as "N/A" and note it.
+- **Breakeven analysis:** Only report project counts above/below breakeven if the dossier contains actual breakeven data for those projects. Do not reason from general Alberta oil sands knowledge.
+
+Fabricated values are a harder editorial failure than missing values. A report with honest gaps is trustworthy; a report with fabricated fields is not.
+
+**In the completion summary, explicitly list every field where dossier data was missing and you left it N/A.** This is how you prove Rule 5 compliance.
+
+---
+
+## Word Count Targets (+50% boost over actual production baseline)
+
+These targets are anchored to the **actual word counts** the four legacy writers produced in the most recent production briefing, not the stale numbers in the old skill files. The old skill targets were wrong.
+
+| Section | Actual baseline | **+50% target** | Min | Max |
+|---|---|---|---|---|
+| Market Commentary (2 paragraphs) | 252 | **378** | 340 | 420 |
+| Equities (4 indices, TSX-weighted) | 284 | **426** | 380 | 475 |
+| FX commentary | 134 | **201** | 180 | 225 |
+| Yield curve commentary | 133 | **200** | 175 | 225 |
+| Commodities summary paragraph | 128 | **192** | 170 | 210 |
+| Per-commodity narratives (13) | 732 | **1,098** | 980 | 1,210 |
+| **TOTAL** | **1,663** | **~2,495** | **2,225** | **2,765** |
+
+Hit the target column. Do not pad to hit Max; do not short to Min. If a section comes in below its Min, the dossier did not give you enough to write with — that is a real problem and you should surface it in the completion summary. Do not compensate by fabricating.
+
+---
+
+## Sub-Section 1 — Market Commentary
+
+Output file: `docs/data/briefing_market_commentary.json`
+
+### Structure
+
+**Paragraph 1 — Market Overview (110–150 words, target 130)**
+- `<span class="lead-sentence">` opening summarizing the week's dominant theme
+- 3–4 specific market data points across equities/FX/yields/commodities
+- Pipeline connection sentence (total project database size/value)
+
+**Paragraph 2 — Cross-Reference (110–150 words, target 135)**
+- `<span class="lead-sentence">` opening framing the pipeline's exposure to this week's moves
+- Rate-sensitive project count + value
+- Commodity-exposed project count + value
+- Conditional framing: "If [condition holds], [X projects] would..."
+
+### Output JSON shape
+
+```json
+{
+  "market_commentary": "<paragraph 1 HTML><paragraph 2 HTML>",
+  "market_commentary_callout": {
+    "title": "Pipeline Cross-Reference",
+    "items": [
+      {"label": "Rate-sensitive projects", "value": "N projects", "amount": "$X.XB"},
+      {"label": "Energy breakeven exposure", "value": "N projects above spot", "amount": "$X.XB"},
+      {"label": "Mining commodity-linked", "value": "N projects", "amount": "$X.XB"}
+    ]
+  },
+  "sources": [ {"id": 1, "title": "...", "url": "..."}, ... ]
+}
+```
+
+---
+
+## Sub-Section 2 — Equities
+
+Output file: `docs/data/briefing_market_equities.json`
+
+### Structure
+
+Produce per-index narratives for **TSX Composite (detailed), S&P 500, DJIA, Nasdaq Composite**. TSX gets the most detail — sub-index breakdown + cross-reference. US indices get concise narratives.
+
+- **TSX Composite:** 75–105 words (target 90) — index close, weekly %, sub-index breakdown (materials/energy/financials), 52-week range, YoY, cross-reference to mining or energy projects if sub-indices moved >2%
+- **S&P 500:** 30–45 words (target 35)
+- **DJIA:** 30–45 words (target 35)
+- **Nasdaq Composite:** 22–35 words (target 25)
+
+Each narrative opens with `<span class="lead-sentence">` on the first phrase (index level + weekly % change).
+
+**Only the TSX cross-references the project database.** US indices do not.
+
+### Output JSON shape
+
+```json
+{
+  "equities": [
+    {
+      "name": "TSX Composite", "symbol": "^GSPTSE",
+      "value": "...", "weekly_pct": "...", "ytd_pct": "...", "yoy_pct": "...",
+      "high_52w": "...", "low_52w": "...",
+      "commentary": "<TSX HTML>"
+    },
+    { "name": "S&P 500", "symbol": "^GSPC", ..., "commentary": "<S&P HTML>" },
+    { "name": "DJIA", "symbol": "^DJI", ..., "commentary": "<DJIA HTML>" },
+    { "name": "Nasdaq Composite", "symbol": "^IXIC", ..., "commentary": "<Nasdaq HTML>" }
+  ],
+  "sources": [ ... ]
+}
+```
+
+All 4 indices are required. Required fields per index: name, symbol, value, weekly_pct, ytd_pct, yoy_pct, high_52w, low_52w, commentary.
+
+---
+
+## Sub-Section 3 — FX and Yields
+
+Output file: `docs/data/briefing_market_fx_yields.json`
+
+### Structure
+
+**FX narrative (60–90 words, target 75)**
+- Em dash lead with CAD/USD rate + weekly % change
+- BoC-Fed rate differential in basis points (always required)
+- Monthly and yearly % change
+- EUR/USD or GBP/USD in one sentence
+- Trade-exposed project count + value cross-reference
+
+**Yield curve narrative (90–135 words, target 115)**
+- Em dash lead with curve shape (normal/inverted) + 2–10 spread in basis points
+- 2Y and 10Y weekly moves in basis points
+- Full curve snapshot: 3M, 1Y, 2Y, 5Y, 10Y, 20Y, 30Y current values
+- Year-ago comparison with basis point changes for 2Y and 10Y at minimum
+- Rate-sensitive project count + value cross-reference
+
+### Output JSON shape
+
+```json
+{
+  "fx": {
+    "pairs": [
+      {"name": "CAD/USD", "value": "...", "weekly_pct": "...", "mom_pct": "...", "yoy_pct": "..."},
+      {"name": "USD/CAD", ...},
+      {"name": "EUR/USD", ...},
+      {"name": "GBP/USD", ...}
+    ],
+    "boc_rate": "...",
+    "fed_rate": "...",
+    "rate_differential_bp": 125,
+    "fx_commentary": "<FX HTML>"
+  },
+  "yieldCurve": {
+    "tenors": [
+      {"tenor": "3M", "current": "...", "year_ago": "...", "change_bp": -185},
+      {"tenor": "1Y", ...}, {"tenor": "2Y", ...}, {"tenor": "5Y", ...},
+      {"tenor": "10Y", ...}, {"tenor": "20Y", ...}, {"tenor": "30Y", ...}
+    ],
+    "spread_2_10": "...",
+    "spread_2_10_prior_week": "...",
+    "curve_shape": "normal",
+    "boc_rate": "...",
+    "yield_commentary": "<Yield HTML>"
+  },
+  "sources": [ ... ]
+}
+```
+
+All 7 tenors are required. CAD/USD narrative MUST include the BoC-Fed rate differential.
+
+---
+
+## Sub-Section 4 — Commodities
+
+Output file: `docs/data/briefing_market_commodities.json`
+
+### Structure
+
+**Summary paragraph (80–120 words, target 100)**
+- `<span class="lead-sentence">` opening summarizing the week's overall commodity picture
+- Category breakdown (energy / precious metals / base metals / agriculture / forest products) in one sweep
+- WCS discount mention
+- Total commodity-linked project value cross-reference
+
+**Per-commodity narratives — all 13 required, no skipping**
+
+| Commodity | Target words | Min | Max |
+|---|---|---|---|
+| WTI Crude Oil | 70 | 60 | 90 — requires breakeven analysis |
+| Western Canadian Select | 55 | 45 | 75 — requires WCS discount calculation |
+| Brent Crude | 28 | 22 | 35 |
+| Natural Gas (Henry Hub) | 45 | 37 | 52 |
+| Gold | 45 | 37 | 52 |
+| Silver | 27 | 22 | 30 |
+| Copper | 37 | 30 | 45 |
+| Uranium | 37 | 30 | 45 |
+| Nickel | 30 | 22 | 37 |
+| Wheat | 30 | 22 | 37 |
+| Canola | 30 | 22 | 37 |
+| Potash | 30 | 22 | 37 |
+| Lumber | 45 | 37 | 52 |
+| **Per-commodity total** | **~510** | **~420** | **~625** |
+
+Each commodity uses this em dash pattern:
+
+```html
+<p><strong>{Name}:</strong> <strong>{Price with units}</strong>
+(<strong>{weekly_pct}</strong> week-over-week) — {1–3 sentences:
+driver of the move + Canadian project cross-reference}<sup>N</sup>.
+{Optional: YoY context or 52-week range}<sup>N</sup>.</p>
+```
+
+### WCS Discount Analysis (required)
+
+```
+WCS Discount = WTI Price - WCS Price
+```
+
+Report: current discount $/bbl, prior week's discount, direction (widened/narrowed), impact on heavy crude producer netbacks, count of Alberta oil sands projects with production costs above the WCS netback price.
+
+### WTI Breakeven Analysis (required)
+
+Count of energy projects with estimated breakeven costs above the current WTI price. Total dollar value of those projects. Geographic concentration (provinces).
+
+### Output JSON shape
+
+```json
+{
+  "commodity_commentary": "<summary paragraph HTML>",
+  "commodities": [
+    {
+      "name": "WTI Crude Oil", "symbol": "CL=F", "category": "Energy",
+      "price": "US$67.20/bbl", "weekly_pct": "-6.7%", "mom_pct": "...", "yoy_pct": "...",
+      "high_52w": "...", "low_52w": "...", "avg_1y": "...",
+      "projects_affected": 312,
+      "projects_above_breakeven": 23,
+      "projects_above_breakeven_value": "$8.2B",
+      "commentary": "<WTI HTML>"
+    },
+    { "name": "Western Canadian Select", ..., "wcs_discount": "US$12.40/bbl",
+      "wcs_discount_prior_week": "US$10.80/bbl", "commentary": "<WCS HTML>" },
+    // ...11 more: Brent, Natural Gas (Henry Hub), Gold, Silver, Copper,
+    //   Uranium, Nickel, Wheat, Canola, Potash, Lumber
+  ],
+  "wcs_analysis": {
+    "wcs_price": "...", "wti_price": "...",
+    "discount": "...", "discount_prior_week": "...",
+    "discount_direction": "widened",
+    "projects_above_breakeven": 8, "projects_above_breakeven_value": "$4.1B"
+  },
+  "sources": [ ... ]
+}
+```
+
+All 13 commodities required. All 5 categories must appear. WCS analysis is required. WTI must include `projects_above_breakeven`.
+
+---
+
+## Step-by-Step Process
+
+### Step 1 — Single dossier read
+
+```python
+import json
+dossier = json.load(open('docs/data/dossier_macro.json', encoding='utf-8'))
+fmp = dossier.get('financial_markets_package', {})
+sources_registry = dossier.get('sources_registry', [])
+```
+
+Extract everything you need from `fmp` into local variables before writing anything. Do not re-read the dossier per sub-section.
+
+### Step 2 — Identify the week's themes (one mental pass)
+
+Classify the week into one dominant narrative:
+- **Broad sell-off** — lead commentary with the biggest mover
+- **Sector divergence** — lead commentary with the split
+- **Rate-driven** — BoC/Fed action or yield curve move dominated
+- **Commodity shock** — oil/gold/agri drove everything
+- **FX-driven** — currency move was the primary story
+
+The theme feeds Paragraph 1 of the commentary. The other sub-sections report their own data regardless.
+
+### Step 3 — Write all four sub-sections in order
+
+Write commentary → equities → FX/yields → commodities. Within each, write the HTML body first, then wrap it in the JSON shape.
+
+Use sources by ID consistently. If source #1 is "TMX Group — TSX Data" in the commentary file, it must be source #1 everywhere you cite TSX data across the four output files (but each file's `sources[]` array only contains the sources that file actually cites).
+
+### Step 4 — Write the four output files
+
+```python
+import json
+
+with open('docs/data/briefing_market_commentary.json', 'w', encoding='utf-8') as f:
+    json.dump(commentary_payload, f, indent=2, ensure_ascii=False)
+
+with open('docs/data/briefing_market_equities.json', 'w', encoding='utf-8') as f:
+    json.dump(equities_payload, f, indent=2, ensure_ascii=False)
+
+with open('docs/data/briefing_market_fx_yields.json', 'w', encoding='utf-8') as f:
+    json.dump(fx_yields_payload, f, indent=2, ensure_ascii=False)
+
+with open('docs/data/briefing_market_commodities.json', 'w', encoding='utf-8') as f:
+    json.dump(commodities_payload, f, indent=2, ensure_ascii=False)
+```
+
+### Step 5 — Validate all four files
+
+Run the consolidated validator below against every output file.
+
+```python
+import json, re
+
+def wc(html):
+    return len(re.sub(r'<[^>]+>', '', html or '').split())
+
+BANNED = ['should', 'must', 'hopefully', 'unfortunately', 'worrying',
+          'promising', 'encouraging', 'welcome', 'bullish', 'bearish',
+          'concerning', 'good news', 'bad news', 'optimistic', 'pessimistic',
+          'troubling', 'reassuring', 'robust', 'notably', 'soaring',
+          'plunging', 'tumbling', 'cratering', 'skyrocketing']
+
+# Taxonomy key leakage patterns — words containing underscores that are
+# field names, not natural English. Any underscored token in user-facing
+# HTML is a craft failure.
+TAXONOMY_LEAK_PATTERN = re.compile(r'\b\w+_\w+\b')
+
+# Historical benchmark phrases — at least 3 required per output file
+BENCHMARK_PATTERNS = [
+    r'since \w+ \d{4}',               # "since July 2022"
+    r'since (?:January|February|March|April|May|June|July|August|September|October|November|December)',
+    r'highest[^.]{0,40}\d',           # "highest level in N months"
+    r'lowest[^.]{0,40}\d',            # "lowest in N weeks"
+    r'first[^.]{0,40}since',          # "first close above X since"
+    r'largest[^.]{0,40}since',        # "largest gain since"
+    r'steepest[^.]{0,40}since',
+    r'52-week (?:high|low)',          # "52-week high"
+    r'year-over-year[^.]{0,60}from',  # "up X% year-over-year from"
+    r'contract inception',
+    r'record\b',                      # "record high"
+]
+BENCHMARK_RE = re.compile('|'.join(BENCHMARK_PATTERNS), re.IGNORECASE)
+
+# Causal driver phrases — at least 1 required per major market move
+DRIVER_PATTERNS = [
+    r'\bas\s+(?:the|reports|news|concerns|announcements|data|US|OPEC)',
+    r'\bdriven by',
+    r'\breflecting',
+    r'\bfollowing\s+(?:the|reports|news|a|an)',
+    r'\bon\s+(?:reports|news|concerns|the announcement|expectations)',
+    r'\bamid\s+(?:the|reports|news)',
+    r'\bafter\s+(?:the|reports|news)',
+    r'\bin response to',
+]
+DRIVER_RE = re.compile('|'.join(DRIVER_PATTERNS), re.IGNORECASE)
+
+# Conditional forward-looking framing pattern
+CONDITIONAL_RE = re.compile(r'\b(?:if|should|were)\s+(?:the|WTI|gold|rates|yields|the CAD|the loonie|the dollar|commodity|commodities)[^.]{20,200}would', re.IGNORECASE)
+
+def check_citations(html, sources):
+    refs = set(int(x) for x in re.findall(r'<sup>(\d+)</sup>', html))
+    ids = set(s['id'] for s in sources)
+    orphaned = refs - ids
+    return orphaned
+
+def check_banned(html):
+    hits = [w for w in BANNED if re.search(r'\b' + re.escape(w) + r'\b', html, re.IGNORECASE)]
+    return hits
+
+def check_taxonomy_leak(text):
+    """Find underscored identifiers in user-facing prose."""
+    stripped = re.sub(r'<[^>]+>', '', text or '')
+    hits = TAXONOMY_LEAK_PATTERN.findall(stripped)
+    # filter out legitimate abbreviations
+    allowed = {'year_ago', 'change_bp', 'change_bps'}
+    return [h for h in hits if h not in allowed]
+
+def count_benchmarks(text):
+    stripped = re.sub(r'<[^>]+>', '', text or '')
+    return len(BENCHMARK_RE.findall(stripped))
+
+def count_drivers(text):
+    stripped = re.sub(r'<[^>]+>', '', text or '')
+    return len(DRIVER_RE.findall(stripped))
+
+def count_conditionals(text):
+    stripped = re.sub(r'<[^>]+>', '', text or '')
+    return len(CONDITIONAL_RE.findall(stripped))
+
+# ── Commentary ──
+d = json.load(open('docs/data/briefing_market_commentary.json', encoding='utf-8'))
+html = d.get('market_commentary', '')
+n = wc(html)
+print(f"Commentary: {n} words (target 340-420)")
+assert 340 <= n <= 420, f"FAIL — commentary word count {n}"
+assert '<span class="lead-sentence">' in html, "FAIL — missing lead-sentence in commentary"
+orph = check_citations(html, d.get('sources', []))
+assert not orph, f"FAIL — orphaned citations: {orph}"
+banned = check_banned(html)
+assert not banned, f"FAIL — banned words in commentary: {banned}"
+leaks = check_taxonomy_leak(html)
+assert not leaks, f"FAIL — taxonomy key leakage in commentary: {leaks}"
+drivers = count_drivers(html)
+assert drivers >= 2, f"FAIL — commentary needs >=2 causal drivers, found {drivers}"
+conds = count_conditionals(html)
+assert conds >= 1, f"FAIL — commentary needs >=1 conditional cross-reference, found {conds}"
+print(f"  drivers: {drivers}, conditionals: {conds}")
+
+# ── Equities ──
+d = json.load(open('docs/data/briefing_market_equities.json', encoding='utf-8'))
+assert len(d.get('equities', [])) == 4, "FAIL — need 4 indices"
+names = {e['name'] for e in d['equities']}
+assert names == {'TSX Composite', 'S&P 500', 'DJIA', 'Nasdaq Composite'}, f"FAIL — index names: {names}"
+all_eq_html = ''.join(e.get('commentary', '') for e in d['equities'])
+n = wc(all_eq_html)
+print(f"Equities: {n} words (target 380-475)")
+assert 380 <= n <= 475, f"FAIL — equities word count {n}"
+for e in d['equities']:
+    assert '<span class="lead-sentence">' in e['commentary'], f"FAIL — {e['name']} missing lead"
+orph = check_citations(all_eq_html, d.get('sources', []))
+assert not orph, f"FAIL — orphaned citations: {orph}"
+banned = check_banned(all_eq_html)
+assert not banned, f"FAIL — banned words in equities: {banned}"
+leaks = check_taxonomy_leak(all_eq_html)
+assert not leaks, f"FAIL — taxonomy key leakage in equities: {leaks}"
+drivers = count_drivers(all_eq_html)
+assert drivers >= 2, f"FAIL — equities need >=2 causal drivers, found {drivers}"
+
+# ── FX + Yields ──
+d = json.load(open('docs/data/briefing_market_fx_yields.json', encoding='utf-8'))
+fx_html = d.get('fx', {}).get('fx_commentary', '')
+yc_html = d.get('yieldCurve', {}).get('yield_commentary', '')
+fx_n = wc(fx_html)
+yc_n = wc(yc_html)
+print(f"FX: {fx_n} words (target 180-225), Yields: {yc_n} words (target 175-225)")
+assert 180 <= fx_n <= 225, f"FAIL — FX word count {fx_n}"
+assert 175 <= yc_n <= 225, f"FAIL — Yield word count {yc_n}"
+assert 'basis point' in yc_html.lower() or 'bp' in yc_html.lower(), "FAIL — yield narrative missing basis points"
+combined = fx_html + yc_html
+orph = check_citations(combined, d.get('sources', []))
+assert not orph, f"FAIL — orphaned citations: {orph}"
+banned = check_banned(combined)
+assert not banned, f"FAIL — banned words in FX/Yields: {banned}"
+leaks = check_taxonomy_leak(combined)
+assert not leaks, f"FAIL — taxonomy key leakage in FX/Yields: {leaks}"
+drivers = count_drivers(combined)
+assert drivers >= 2, f"FAIL — FX/Yields need >=2 causal drivers, found {drivers}"
+conds = count_conditionals(combined)
+assert conds >= 1, f"FAIL — FX/Yields need >=1 conditional cross-reference, found {conds}"
+
+# ── Commodities ──
+d = json.load(open('docs/data/briefing_market_commodities.json', encoding='utf-8'))
+comm_list = d.get('commodities', [])
+# No fabrication rule: it is acceptable to have fewer than 13 commodities
+# if the dossier did not provide them. Only validate the ones present.
+assert 1 <= len(comm_list) <= 13, f"FAIL — unexpected commodity count {len(comm_list)}"
+summary_wc = wc(d.get('commodity_commentary', ''))
+per_wc = sum(wc(c.get('commentary', '')) for c in comm_list)
+total_comm = summary_wc + per_wc
+print(f"Commodities: summary {summary_wc} + per {per_wc} = {total_comm} words (target 1150-1420)")
+assert 170 <= summary_wc <= 210, f"FAIL — commodity summary {summary_wc}"
+# Per-commodity target scales with count. Base assumption: 13 commodities → 980-1210.
+if len(comm_list) == 13:
+    assert 980 <= per_wc <= 1210, f"FAIL — per-commodity total {per_wc}"
+all_comm_html = d.get('commodity_commentary', '') + ''.join(c.get('commentary', '') for c in comm_list)
+assert '<span class="lead-sentence">' in d.get('commodity_commentary', ''), "FAIL — commodity summary missing lead"
+orph = check_citations(all_comm_html, d.get('sources', []))
+assert not orph, f"FAIL — orphaned citations: {orph}"
+banned = check_banned(all_comm_html)
+assert not banned, f"FAIL — banned words in commodities: {banned}"
+leaks = check_taxonomy_leak(all_comm_html)
+assert not leaks, f"FAIL — taxonomy key leakage in commodities: {leaks}"
+drivers = count_drivers(all_comm_html)
+assert drivers >= 5, f"FAIL — commodities need >=5 causal drivers across 13 narratives, found {drivers}"
+
+# ── Cross-file craft checks ──
+all_files_html = ''
+for f in ['briefing_market_commentary.json', 'briefing_market_equities.json',
+          'briefing_market_fx_yields.json', 'briefing_market_commodities.json']:
+    d = json.load(open(f'docs/data/{f}', encoding='utf-8'))
+    # collect all commentary HTML across all files
+    all_files_html += d.get('market_commentary', '')
+    for e in d.get('equities', []):
+        all_files_html += e.get('commentary', '')
+    all_files_html += d.get('fx', {}).get('fx_commentary', '')
+    all_files_html += d.get('yieldCurve', {}).get('yield_commentary', '')
+    all_files_html += d.get('commodity_commentary', '')
+    for c in d.get('commodities', []):
+        all_files_html += c.get('commentary', '')
+
+benchmarks = count_benchmarks(all_files_html)
+print(f"\nTotal historical benchmarks across all 4 files: {benchmarks}")
+assert benchmarks >= 3, f"FAIL — need >=3 historical benchmarks across all outputs, found {benchmarks}"
+
+total_drivers = count_drivers(all_files_html)
+total_conds = count_conditionals(all_files_html)
+print(f"Total causal drivers: {total_drivers}")
+print(f"Total conditional cross-references: {total_conds}")
+
+print("\n✓ All four market output files validated, craft rules passed.")
+```
+
+### Step 6 — Signal completion
+
+```
+✓ Agent 3F-MERGED (Markets Writer) complete
+  - Market Commentary: [N] words
+  - Equities (4 indices): [N] words
+  - FX + Yields: [N] words
+  - Commodities (13 items): [N] words (summary [S] + per-commodity [P])
+  - TOTAL: [N] words (target ~1,180)
+  - Sources cited: [N]
+  - Validation: PASS
+
+Output files:
+  docs/data/briefing_market_commentary.json
+  docs/data/briefing_market_equities.json
+  docs/data/briefing_market_fx_yields.json
+  docs/data/briefing_market_commodities.json
+
+Ready for merging by Agent 3E (Assembler).
+```
+
+---
+
+## Common Pitfalls to Avoid
+
+1. **Don't re-read the dossier four times.** Read once in Step 1, hold it in memory for all four sub-sections.
+2. **Don't skip any commodity.** All 13 required, no exceptions.
+3. **Don't skip the WCS discount.** Unique Canadian intelligence — always calculate and report.
+4. **Don't skip the WTI breakeven analysis.** Required in the WTI narrative and the commodities JSON.
+5. **Don't forget the BoC-Fed rate differential.** FX narrative MUST state it in basis points.
+6. **Don't cross-reference US indices.** Only the TSX links to the project database.
+7. **Don't express yield changes as percentages.** Basis points only for small moves.
+8. **Don't editorialize in any sub-section.** The banned-word list is non-negotiable across all four outputs.
+9. **Don't confuse CAD/USD and USD/CAD.** Always provide both pairs with correct labels.
+10. **Don't exceed section maximums.** Individual Max values act as hard caps even if the total fits.
+11. **Don't pad to hit targets.** If the dossier is thin, hit the Min, not the Target.
+12. **Don't let commodities summary duplicate per-commodity content.** Summary is the overview; per-commodity goes deep.
+
+---
+
+## Why This Beats the Four-Writer Split
+
+- **1 dossier read vs 4** — reduces context loading cost by ~75% for the Markets tab
+- **1 editorial review pass vs 4** — the agent holds a unified view of banned words, citation continuity, and source numbering across all four outputs
+- **Source ID consistency** — single agent manages the `sources_registry` subset used per file, eliminating drift between the four legacy writers
+- **Same output files** — the assembler (Agent 3E) and the frontend require no changes
+
+If any of the four sub-sections fails its validation gate, the whole dispatch is a failure. Fix in-place and re-validate before signaling completion.

--- a/.claude/skills/lagging_indicator_charts.md
+++ b/.claude/skills/lagging_indicator_charts.md
@@ -1,6 +1,10 @@
 # The Lagging Indicator — Chart Library
 
-Design system: light theme, `border: 0.5px solid var(--color-border-tertiary)`, `border-radius: var(--border-radius-lg)`, Chart.js 4.4.1 from cdnjs. All charts use `#185FA5` (blue) as primary, `#1D9E75` (teal) as secondary, `#BA7517` (amber), `#D4537E` (pink), `#7F77DD` (purple). Grid lines `rgba(0,0,0,.04)`, tick color `#888780`, axis border `rgba(0,0,0,.08)`.
+Design system: light theme, `border: 1px solid #d5dbe3`, `border-radius: 16px`, `box-shadow: 0 2px 8px rgba(0,0,0,.06)`, Chart.js 4.4.1 from cdnjs. Primary color `#003153` (Prussian blue — matches `--accent-blue` in `docs/index.html`), secondary `#c4320a` (accent red), tertiary `#1D9E75` (teal), `#BA7517` (amber), `#7F77DD` (purple). Grid lines `rgba(0,49,83,.05)`, tick color `#7a8599`, axis border `#e8ecf0`. Font family: `DM Sans`. Text hierarchy: body `#1a1a1a`, muted `#4a5568`, tertiary `#7a8599`.
+
+**Layout variants:**
+- **Legacy (Option A)** — simple card with title + subtitle + canvas. Use for secondary charts, dense visualizations, and anywhere the chart *is* the content.
+- **Editorial (Option C)** — card with eyebrow category label + large title + KPI row above the chart + integrated context panel below. Use for high-priority charts where the reader should see the headline number without interpreting the visual. Trigger in chart specs by providing a non-empty `kpis` array (see `tldr-charts` SKILL.md for the schema).
 
 ---
 
@@ -16,7 +20,7 @@ Design system: light theme, `border: 0.5px solid var(--color-border-tertiary)`, 
   </div>
   <div style="display:flex;gap:16px;margin-bottom:1rem;flex-wrap:wrap;">
     <span style="display:flex;align-items:center;gap:5px;font-size:12px;color:var(--color-text-secondary);">
-      <span style="width:20px;height:2px;background:#185FA5;display:inline-block;border-radius:2px;"></span>Adj. value
+      <span style="width:20px;height:2px;background:#003153;display:inline-block;border-radius:2px;"></span>Adj. value
     </span>
     <span style="display:flex;align-items:center;gap:5px;font-size:12px;color:var(--color-text-secondary);">
       <span style="width:20px;height:2px;background:#B5D4F4;display:inline-block;border-radius:2px;border-top:2px dashed #B5D4F4;"></span>Gross announced
@@ -31,7 +35,7 @@ new Chart(document.getElementById('lineC'),{
   data:{
     labels:['Q1 25','Q2 25','Q3 25','Q4 25','Q1 26'],
     datasets:[
-      {label:'Adj. value',data:[618,641,672,689,703],borderColor:'#185FA5',backgroundColor:'rgba(24,95,165,.07)',pointBackgroundColor:'#185FA5',pointRadius:4,tension:.35,fill:true,borderWidth:2},
+      {label:'Adj. value',data:[618,641,672,689,703],borderColor:'#003153',backgroundColor:'rgba(24,95,165,.07)',pointBackgroundColor:'#003153',pointRadius:4,tension:.35,fill:true,borderWidth:2},
       {label:'Gross',data:[980,1050,1110,1170,1200],borderColor:'#B5D4F4',borderDash:[4,3],pointBackgroundColor:'#B5D4F4',pointRadius:3,tension:.35,fill:false,borderWidth:1.5}
     ]
   },
@@ -76,7 +80,7 @@ data.forEach((d,i)=>{
   row.innerHTML=`
     <div style="width:130px;font-size:12px;color:var(--color-text-secondary);text-align:right;flex-shrink:0;">${d.label}</div>
     <div style="flex:1;background:var(--color-background-secondary);border-radius:3px;height:20px;overflow:hidden;">
-      <div style="width:${d.pct}%;height:100%;background:${i===0?'#185FA5':i<3?'#378ADD':'#85B7EB'};border-radius:3px;"></div>
+      <div style="width:${d.pct}%;height:100%;background:${i===0?'#003153':i<3?'#378ADD':'#85B7EB'};border-radius:3px;"></div>
     </div>
     <div style="width:48px;font-size:12px;font-weight:500;color:var(--color-text-primary);flex-shrink:0;">$${d.value}B</div>
   `;
@@ -98,7 +102,7 @@ data.forEach((d,i)=>{
     <div style="font-size:11px;color:var(--color-text-tertiary);">Bubble size = confidence-adj. value</div>
   </div>
   <div style="display:flex;gap:16px;margin-bottom:1rem;flex-wrap:wrap;">
-    <span style="display:flex;align-items:center;gap:5px;font-size:12px;color:var(--color-text-secondary);"><span style="width:10px;height:10px;border-radius:50%;background:#185FA5;display:inline-block;opacity:.7;"></span>Energy</span>
+    <span style="display:flex;align-items:center;gap:5px;font-size:12px;color:var(--color-text-secondary);"><span style="width:10px;height:10px;border-radius:50%;background:#003153;display:inline-block;opacity:.7;"></span>Energy</span>
     <span style="display:flex;align-items:center;gap:5px;font-size:12px;color:var(--color-text-secondary);"><span style="width:10px;height:10px;border-radius:50%;background:#1D9E75;display:inline-block;opacity:.7;"></span>Infrastructure</span>
     <span style="display:flex;align-items:center;gap:5px;font-size:12px;color:var(--color-text-secondary);"><span style="width:10px;height:10px;border-radius:50%;background:#BA7517;display:inline-block;opacity:.7;"></span>Mining</span>
     <span style="display:flex;align-items:center;gap:5px;font-size:12px;color:var(--color-text-secondary);"><span style="width:10px;height:10px;border-radius:50%;background:#7F77DD;display:inline-block;opacity:.7;"></span>Cleantech</span>
@@ -140,7 +144,7 @@ new Chart(document.getElementById('bubC'),{
     <div style="font-size:11px;color:var(--color-text-tertiary);">Quarterly · 2024 Q1 – 2026 Q1</div>
   </div>
   <div style="display:flex;gap:16px;margin-bottom:1rem;flex-wrap:wrap;">
-    <span style="display:flex;align-items:center;gap:5px;font-size:12px;color:var(--color-text-secondary);"><span style="width:20px;height:2px;background:#185FA5;display:inline-block;border-radius:2px;"></span>Under construction</span>
+    <span style="display:flex;align-items:center;gap:5px;font-size:12px;color:var(--color-text-secondary);"><span style="width:20px;height:2px;background:#003153;display:inline-block;border-radius:2px;"></span>Under construction</span>
     <span style="display:flex;align-items:center;gap:5px;font-size:12px;color:var(--color-text-secondary);"><span style="width:20px;height:2px;background:#1D9E75;display:inline-block;border-radius:2px;"></span>FID reached</span>
   </div>
   <div style="position:relative;width:100%;height:220px;"><canvas id="areaC"></canvas></div>
@@ -152,7 +156,7 @@ new Chart(document.getElementById('areaC'),{
   data:{
     labels:['Q1 24','Q2 24','Q3 24','Q4 24','Q1 25','Q2 25','Q3 25','Q4 25','Q1 26'],
     datasets:[
-      {label:'Under construction',data:[44,46,49,51,53,55,57,59,61],borderColor:'#185FA5',backgroundColor:'rgba(24,95,165,.08)',fill:true,tension:.4,pointRadius:3,pointBackgroundColor:'#185FA5',borderWidth:2},
+      {label:'Under construction',data:[44,46,49,51,53,55,57,59,61],borderColor:'#003153',backgroundColor:'rgba(24,95,165,.08)',fill:true,tension:.4,pointRadius:3,pointBackgroundColor:'#003153',borderWidth:2},
       {label:'FID reached',data:[38,39,41,40,42,43,45,43,44],borderColor:'#1D9E75',backgroundColor:'rgba(29,158,117,.08)',fill:true,tension:.4,pointRadius:3,pointBackgroundColor:'#1D9E75',borderWidth:2}
     ]
   },
@@ -182,7 +186,7 @@ new Chart(document.getElementById('areaC'),{
 </div>
 <script>
 const sectors=[
-  {label:'Energy',pct:38,color:'#185FA5'},
+  {label:'Energy',pct:38,color:'#003153'},
   {label:'Infrastructure',pct:22,color:'#1D9E75'},
   {label:'Mining',pct:18,color:'#BA7517'},
   {label:'Real estate',pct:12,color:'#D4537E'},
@@ -218,7 +222,7 @@ const deltas=[
   {label:'New entries',value:'+$2.1B',c:'#E1F5EE',tc:'#0F6E56'},
   {label:'Upward rev.',value:'+$3.8B',c:'#E1F5EE',tc:'#0F6E56'},
   {label:'Deferrals',value:'-$3.7B',c:'#FCEBEB',tc:'#A32D2D'},
-  {label:'Net change',value:'+$14B',c:'#E6F1FB',tc:'#185FA5'},
+  {label:'Net change',value:'+$14B',c:'#E6F1FB',tc:'#003153'},
 ];
 const dc=document.getElementById('delta-cards');
 deltas.forEach(d=>{
@@ -241,7 +245,7 @@ deltas.forEach(d=>{
   <div style="font-size:13px;font-weight:500;color:var(--color-text-primary);margin-bottom:1rem;">Projects by sector and stage</div>
   <div style="position:relative;width:100%;height:180px;"><canvas id="groupC"></canvas></div>
   <div style="display:flex;gap:14px;margin-top:10px;">
-    <span style="display:flex;align-items:center;gap:5px;font-size:11px;color:var(--color-text-secondary);"><span style="width:9px;height:9px;border-radius:2px;background:#185FA5;display:inline-block;"></span>Construction</span>
+    <span style="display:flex;align-items:center;gap:5px;font-size:11px;color:var(--color-text-secondary);"><span style="width:9px;height:9px;border-radius:2px;background:#003153;display:inline-block;"></span>Construction</span>
     <span style="display:flex;align-items:center;gap:5px;font-size:11px;color:var(--color-text-secondary);"><span style="width:9px;height:9px;border-radius:2px;background:#85B7EB;display:inline-block;"></span>FID reached</span>
     <span style="display:flex;align-items:center;gap:5px;font-size:11px;color:var(--color-text-secondary);"><span style="width:9px;height:9px;border-radius:2px;background:#D3D1C7;display:inline-block;"></span>Planning</span>
   </div>
@@ -253,7 +257,7 @@ new Chart(document.getElementById('groupC'),{
   data:{
     labels:['Energy','Infrastructure','Mining','Real estate','Cleantech'],
     datasets:[
-      {label:'Construction',data:[18,14,12,9,4],backgroundColor:'#185FA5',borderWidth:0,borderRadius:3,barThickness:12},
+      {label:'Construction',data:[18,14,12,9,4],backgroundColor:'#003153',borderWidth:0,borderRadius:3,barThickness:12},
       {label:'FID reached',data:[12,8,10,7,4],backgroundColor:'#85B7EB',borderWidth:0,borderRadius:3,barThickness:12},
       {label:'Planning',data:[8,10,6,7,2],backgroundColor:'#D3D1C7',borderWidth:0,borderRadius:3,barThickness:12}
     ]
@@ -283,7 +287,7 @@ new Chart(document.getElementById('groupC'),{
 </div>
 <script>
 const rangeData=[
-  {label:'Energy',min:0.2,med:2.1,max:14.0,color:'#185FA5'},
+  {label:'Energy',min:0.2,med:2.1,max:14.0,color:'#003153'},
   {label:'Infrastructure',min:0.1,med:1.4,max:6.8,color:'#1D9E75'},
   {label:'Mining',min:0.3,med:1.8,max:9.1,color:'#BA7517'},
   {label:'Real estate',min:0.1,med:0.9,max:4.2,color:'#D4537E'},
@@ -324,7 +328,7 @@ rangeData.forEach(d=>{
     <div style="font-size:11px;color:var(--color-text-tertiary);">Quarterly · 2024 Q1 – 2026 Q1</div>
   </div>
   <div style="display:flex;gap:14px;margin-bottom:1rem;">
-    <span style="display:flex;align-items:center;gap:5px;font-size:11px;color:var(--color-text-secondary);"><span style="width:9px;height:9px;border-radius:2px;background:#185FA5;display:inline-block;"></span>Construction</span>
+    <span style="display:flex;align-items:center;gap:5px;font-size:11px;color:var(--color-text-secondary);"><span style="width:9px;height:9px;border-radius:2px;background:#003153;display:inline-block;"></span>Construction</span>
     <span style="display:flex;align-items:center;gap:5px;font-size:11px;color:var(--color-text-secondary);"><span style="width:9px;height:9px;border-radius:2px;background:#1D9E75;display:inline-block;"></span>FID reached</span>
     <span style="display:flex;align-items:center;gap:5px;font-size:11px;color:var(--color-text-secondary);"><span style="width:9px;height:9px;border-radius:2px;background:#B4B2A9;display:inline-block;"></span>Planning</span>
   </div>
@@ -337,7 +341,7 @@ new Chart(document.getElementById('stackareaC'),{
   data:{
     labels:['Q1 24','Q2 24','Q3 24','Q4 24','Q1 25','Q2 25','Q3 25','Q4 25','Q1 26'],
     datasets:[
-      {label:'Construction',data:[44,46,49,51,53,55,57,59,61],borderColor:'#185FA5',backgroundColor:'rgba(24,95,165,.15)',fill:true,tension:.4,pointRadius:0,borderWidth:1.5},
+      {label:'Construction',data:[44,46,49,51,53,55,57,59,61],borderColor:'#003153',backgroundColor:'rgba(24,95,165,.15)',fill:true,tension:.4,pointRadius:0,borderWidth:1.5},
       {label:'FID reached',data:[38,39,41,40,42,43,45,43,44],borderColor:'#1D9E75',backgroundColor:'rgba(29,158,117,.15)',fill:true,tension:.4,pointRadius:0,borderWidth:1.5},
       {label:'Planning',data:[28,30,31,33,34,36,37,38,37],borderColor:'#B4B2A9',backgroundColor:'rgba(180,178,169,.15)',fill:true,tension:.4,pointRadius:0,borderWidth:1.5}
     ]
@@ -367,7 +371,7 @@ new Chart(document.getElementById('stackareaC'),{
 </div>
 <script>
 const projects=[
-  {label:'LNG Canada Ph.2',start:2022,end:2027,color:'#185FA5'},
+  {label:'LNG Canada Ph.2',start:2022,end:2027,color:'#003153'},
   {label:'Rideau Corridor',start:2025,end:2028,color:'#1D9E75'},
   {label:'NS Offshore Wind',start:2026,end:2031,color:'#BA7517'},
   {label:'Atikokan H2',start:2027,end:2030,color:'#7F77DD'},

--- a/.claude/skills/tldr-analyst-macro/SKILL.md
+++ b/.claude/skills/tldr-analyst-macro/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: tldr-analyst-macro
+context: fork
 description: >
   Produces macro-level analytical dossier for "The Lagging Indicator" dashboard.
   Synthesizes national economic research (Agent 1A) with hard pipeline data to build
@@ -290,7 +291,29 @@ Pull global data from research_macro.md and hard data. For each region, identify
 
 ### Step 8: Build Financial Markets Package (8 minutes)
 
-Carry forward structure from briefing_latest.json:
+Carry forward structure from briefing_latest.json, but the commodities array MUST be built from `docs/data/timeseries.json` — not from briefing_latest or commodities.json — so that the dossier is the single source of truth for every downstream Markets writer.
+
+**The commodities array must cover all 13 canonical commodities** used by the Markets tab. The Markets triad writer (Agent 3-TRIAD) depends on this; if you omit commodities, the writer cannot produce them honestly.
+
+#### Canonical commodity list (13) and the timeseries.json keys that feed them
+
+| # | Commodity name (use exactly) | `timeseries.json` key | Unit | Fallback if stale/missing |
+|---|---|---|---|---|
+| 1 | WTI Crude Oil | `wti` | US$/bbl | — (always available) |
+| 2 | Western Canadian Select | *(not in timeseries)* | US$/bbl | Compute as `WTI - wcs_differential` if `wcs_differential` is available in a data file; otherwise set `"price": "N/A"` with a `note` field explaining the dossier does not carry WCS data |
+| 3 | Brent Crude | `brent` | US$/bbl | — |
+| 4 | Natural Gas (Henry Hub) | `natural_gas` | US$/MMBtu | — |
+| 5 | Gold | `gold` | US$/oz | — |
+| 6 | Silver | `silver` | US$/oz | — |
+| 7 | Copper | `copper` | US$/lb | — |
+| 8 | Uranium | `sprott_uranium` (preferred) or `cameco_uranium` | US$/lb (Sprott) or CAD$ (Cameco proxy) | — |
+| 9 | Nickel | `nickel` | US$/t | **If latest date > 90 days old, mark `"price": "N/A"` with stale-data note.** Do not publish stale values as current. |
+| 10 | Wheat | `wheat` | US¢/bu | — |
+| 11 | Canola | `canola` | CAD$/t | **If latest date > 90 days old, mark `"price": "N/A"` with stale-data note.** |
+| 12 | Potash | `potash_nutrien` (proxy) | US$ (stock price) | — |
+| 13 | Lumber | `lumber` | US$/mfbm | — |
+
+#### Output shape
 
 ```json
 {
@@ -298,25 +321,49 @@ Carry forward structure from briefing_latest.json:
     "indices": [
       {"label": "TSX", "value": "22,456", "change": "+1.2%", "period": "Week"},
       {"label": "S&P 500", "value": "5,123", "change": "+0.8%", "period": "Week"},
-      {"label": "NASDAQ", "value": "16,234", "change": "+1.1%", "period": "Week"}
+      {"label": "NASDAQ", "value": "16,234", "change": "+1.1%", "period": "Week"},
+      {"label": "DJIA", "value": "48,186", "change": "+0.9%", "period": "Week"}
     ],
     "fx": [
-      {"pair": "CAD/USD", "value": "1.358", "change": "-0.8%", "period": "Week"},
-      {"pair": "CAD/EUR", "value": "1.482", "change": "+0.3%", "period": "Week"}
+      {"pair": "CAD/USD", "value": "0.7235", "change": "-0.8%", "period": "Week"},
+      {"pair": "USD/CAD", "value": "1.3822", "change": "+0.8%", "period": "Week"},
+      {"pair": "EUR/USD", "value": "1.1696", "change": "+0.4%", "period": "Week"}
     ],
     "commodities": [
-      {"name": "WTI Crude", "value": "$68.50/bbl", "change": "-2.1%", "period": "Week"},
-      {"name": "Natural Gas", "value": "$2.85/mmbtu", "change": "+1.5%", "period": "Week"}
+      {"name": "WTI Crude Oil", "value": "$98.53/bbl", "weekly_pct": "-1.59%", "mom_pct": "+18.07%", "yoy_pct": "+65.37%", "avg_1y": "$65.99/bbl", "high_52w": "$112.95/bbl", "low_52w": "$58.70/bbl", "source": "timeseries.json:wti"},
+      {"name": "Western Canadian Select", "value": "N/A", "note": "Dossier does not carry WCS pricing this week; Markets writer should report wcs_analysis as N/A.", "source": "unavailable"},
+      {"name": "Brent Crude", "value": "$96.52/bbl", "weekly_pct": "-0.99%", "mom_pct": "...", "source": "timeseries.json:brent"},
+      {"name": "Natural Gas (Henry Hub)", "value": "$2.67/MMBtu", "weekly_pct": "-5.21%", "source": "timeseries.json:natural_gas"},
+      {"name": "Gold", "value": "$4,782.60/oz", "weekly_pct": "+0.4%", "source": "timeseries.json:gold"},
+      {"name": "Silver", "value": "$75.46/oz", "weekly_pct": "+0.1%", "source": "timeseries.json:silver"},
+      {"name": "Copper", "value": "$5.75/lb", "weekly_pct": "-0.1%", "source": "timeseries.json:copper"},
+      {"name": "Uranium", "value": "$50.93/lb (Sprott proxy)", "weekly_pct": "+3.39%", "source": "timeseries.json:sprott_uranium"},
+      {"name": "Nickel", "value": "N/A", "note": "timeseries.json:nickel has not updated since 2015-07-01; mark stale. Do not publish.", "source": "unavailable"},
+      {"name": "Wheat", "value": "$573.50/bu", "weekly_pct": "...", "source": "timeseries.json:wheat"},
+      {"name": "Canola", "value": "N/A", "note": "timeseries.json:canola has not updated since 2001-02-01; mark stale. Do not publish.", "source": "unavailable"},
+      {"name": "Potash", "value": "$72.78 (Nutrien proxy)", "weekly_pct": "-2.39%", "source": "timeseries.json:potash_nutrien"},
+      {"name": "Lumber", "value": "$579.50/mfbm", "weekly_pct": "...", "source": "timeseries.json:lumber"}
     ],
     "yieldCurve": {
       "current": [2.97, 3.05, 3.10, 3.30, 3.48, 3.97],
       "lastYear": [2.37, 2.39, 2.52, 2.69, 2.89, 3.19]
-    }
+    },
+    "wcs_analysis": null
   }
 }
 ```
 
-Carry forward exactly from briefing_latest.json and commodities.json. Never fabricate or estimate financial data.
+#### Rules
+
+1. **Always produce all 13 commodity entries.** Missing commodities must appear in the array with `"price": "N/A"` and a `note` field — never silently omit them. The triad writer depends on finding the full 13 to mark N/A honestly in its output.
+2. **Every non-N/A entry must cite its `source`** (e.g., `"timeseries.json:wti"`) so downstream agents can trace the value back.
+3. **Stale data (> 90 days since last datapoint) must be marked N/A.** Do not publish 2015 nickel prices or 2001 canola prices as current. The timeseries.json key for those exists, but the data is stale — mark N/A with a clear note.
+4. **Compute week-over-week, month-over-month, and year-over-year changes from timeseries.json** directly — take the current value vs the value 7 / 30 / 365 days prior. If any comparison window has no data, mark that specific field N/A (not the whole entry).
+5. **52-week high/low, 1-year average** should be computed from the trailing 365 days of timeseries data for each commodity that has it.
+6. **Never fabricate.** Never interpolate between two points to fill a missing date. Never use general market knowledge to fill a missing commodity. Never carry forward last week's value as this week's.
+7. **WCS handling:** if no WCS feed is available, set the top-level `wcs_analysis` to `null` and include the WCS entry in commodities with `"price": "N/A"` and a note. The Markets writer will then correctly mark the WCS analysis block as unavailable instead of fabricating a discount.
+
+Other financial market fields (indices, fx, yieldCurve) can still carry forward from briefing_latest.json as today. Never fabricate or estimate financial data for those either.
 
 ### Step 9: Build Consumer Pulse Package (8 minutes)
 

--- a/.claude/skills/tldr-assembler/SKILL.md
+++ b/.claude/skills/tldr-assembler/SKILL.md
@@ -1,9 +1,13 @@
 ---
 name: tldr-assembler
+disable-model-invocation: true
+model: claude-haiku-4-5-20251001
 description: >
-  Mechanical merger of eight writing fragments plus optional visualization manifest into one
-  complete briefing JSON for "The Lagging Indicator" dashboard. Runs after all eight writing
-  agents (3A, 3B, 3C, 3D, 3F, 3G, 3H, 3I) and the visualizer (Phase 3.25) complete. Merges
+  Mechanical merger of seven writing fragments plus optional visualization manifest into one
+  complete briefing JSON for "The Lagging Indicator" dashboard. Runs on Claude Haiku 4.5 —
+  purely mechanical work (JSON merge, source de-duplication, citation re-numbering, schema
+  validation) with no creative writing or editorial judgment. Runs after all six writing
+  agents (3A, 3B, 3C, 3D, 3F, 3-TRIAD) and the visualizer (Phase 3.25) complete. Merges
   briefing_macro.json, briefing_provinces.json, briefing_goods.json, briefing_services.json,
   briefing_market_commentary.json, briefing_market_equities.json, briefing_market_fx_yields.json,
   and briefing_market_commodities.json into a single output file. Integrates inline SVG charts
@@ -11,7 +15,7 @@ description: >
   de-duplication, citation re-numbering, and schema validation. NO creative writing — purely
   mechanical merge and validation. Trigger on phrases like "assemble the briefing", "merge the
   fragments", "combine the writers", "run the assembler", "Agent 3E", "assembly phase", "build
-  the final JSON", or when all eight writers and the visualizer have completed their output.
+  the final JSON", or when all six writers and the visualizer have completed their output.
 ---
 
 # TL;DR Assembler — Agent 3E

--- a/.claude/skills/tldr-charts/SKILL.md
+++ b/.claude/skills/tldr-charts/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: tldr-charts
+context: fork
 description: >
-  Generates two insight charts per province and for Canada (National tab) to visually support the
-  weekly briefing's major findings. Reads the completed briefing JSON and analyst dossier, selects
-  the best chart types from the 10-chart design library, populates them with real data from
-  timeseries.json and the project database, and writes the chart specs back into the briefing JSON.
-  Trigger on phrases like "generate charts", "create visuals", "run the chart agent", "add charts
-  to the briefing", "generate infographics", "chart agent", "tldr charts", or any request to add
-  data visualizations to the weekly briefing.
+  Generates insight charts for Canada (National tab), each province, and each of the 20 NAICS
+  industries to visually support the weekly briefing's major findings. Reads the completed
+  briefing JSON and analyst dossier, selects the best chart type from the chart vocabulary,
+  populates charts with real data from indicators.json history (primary, StatCan) and
+  timeseries.json (secondary, commodities/markets), and writes the chart specs back into the
+  briefing JSON. Trigger on phrases like "generate charts", "create visuals", "run the chart
+  agent", "add charts to the briefing", "generate infographics", "chart agent", "tldr charts",
+  or any request to add data visualizations to the weekly briefing.
 ---
 
 # TL;DR Charts — Agent 4
 
-You are the fourth agent in the pipeline that produces a weekly Canadian economic intelligence briefing for "The Lagging Indicator" dashboard. Your role is **The Chart Agent**: you read the completed briefing narrative (Agent 3 output), identify the two most important findings for Canada nationally and for each province, select the best chart type to visualize each finding, populate the chart with real data, and write the chart specifications into the briefing JSON.
+You are the fourth agent in the pipeline that produces a weekly Canadian economic intelligence briefing for "The Lagging Indicator" dashboard. Your role is **The Chart Agent**: you read the completed briefing narrative (Agent 3 output), identify the most important findings for Canada nationally, each province, and each of the 20 NAICS industries, select the best chart type to visualize each finding, populate the chart with real data, and write the chart specifications into the briefing JSON.
 
 Your output goes live. The chart specs you write are rendered directly by the frontend. Every data point must be real — never fabricate or estimate data.
 
@@ -26,11 +28,11 @@ Read these files in order:
 
 1. `docs/data/briefing_latest.json` — The completed briefing (your primary input)
 2. `docs/data/analyst_dossier.json` — The analyst's raw dossier (for deeper data context)
-3. `docs/data/timeseries.json` — Historical time-series data (102 keys, your chart data source)
-4. `.claude/skills/lagging_indicator_charts.md` — The 10-chart design library (your visual vocabulary)
+3. `docs/data/indicators.json` — **StatCan indicators + history** (primary data source for industries and structural economic series). Contains `indicators[]` (current values) and `history[]` (~44,700 rows, up to ~5 years per series). This is where the 20 `gdp_*` industry series, sector employment, building investment components, yield curve, and other StatCan-sourced time series live.
+4. `docs/data/timeseries.json` — Historical time-series data (117 keys — commodities, equity indices, FX, crypto, bond spreads). Secondary data source for market-driven series not in indicators.json.
+5. `.claude/skills/lagging_indicator_charts.md` — The chart design library (your visual vocabulary)
 
 Also consult:
-- `docs/data/indicators.json` — Current provincial/national indicators
 - `docs/data/pipeline_status.json` — Project pipeline status data (for pipeline-themed charts)
 - `docs/data/projects_all.json` — Full project database (for sector/province aggregations)
 
@@ -90,26 +92,150 @@ Add an `insightCharts` array (length 2) to EACH province object in `provinces[]`
 }
 ```
 
+### 3. Industry Charts (1 chart each)
+Add an `insightCharts` array (length 1) to EACH industry object in `goodsIndustries[]` and `servicesIndustries[]` (20 industries total: 5 goods + 15 services):
+
+```json
+{
+  "code": "11",
+  "name": "Agriculture",
+  "insightCharts": [
+    {
+      "chartType": "line",
+      "dataKeys": ["gdp_agriculture"],
+      "dataSource": "indicators",
+      "window": "24m",
+      "title": "Agriculture Real GDP — 24 Month Trajectory",
+      "subtitle": "StatCan 36-10-0434 · Chained 2017 dollars",
+      "yAxisLabel": "Index (2017=100)",
+      "reasoning": "Agriculture GDP posted a third consecutive monthly decline — chart contextualizes the drop against the full 24-month window",
+      "callout": "The trajectory line shows three consecutive monthly declines beginning November 2025, placing the January reading below the entire 2024 range. The 24-month low came after a five-month plateau at 2024 levels."
+    }
+  ]
+}
+```
+
+Multi-line example (when the week's story ties the sector to a complementary series):
+
+```json
+{
+  "code": "52",
+  "name": "Finance & Insurance",
+  "insightCharts": [
+    {
+      "chartType": "multi_line",
+      "dataKeys": ["goc_2y_yield", "goc_5y_yield", "goc_10y_yield"],
+      "dataSource": "indicators",
+      "window": "12m",
+      "title": "GoC Yield Curve — 2y / 5y / 10y",
+      "subtitle": "12-month trajectory · %",
+      "yAxisLabel": "Yield (%)",
+      "reasoning": "Finance sector performance tracks the yield curve shape — slope compression is the week's rate-environment story",
+      "callout": "The 2y line has converged toward the 10y over the window, compressing the curve. The narrowing spread visible between the top and bottom series is the backdrop for bank net-interest margin pressure."
+    }
+  ]
+}
+```
+
 ## Chart Specification Schema
 
 Each chart object in the `insightCharts` array follows this schema:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `chartType` | string | Yes | One of: `line`, `bar`, `diverging_bar` |
-| `dataKeys` | string[] | Yes | 1-2 keys from timeseries.json. These are the actual data series. |
-| `title` | string | Yes | Chart title — factual, specific, under 50 chars |
-| `subtitle` | string | Yes | Time range and unit — e.g. "12-month trend · %" |
-| `reasoning` | string | Yes | Why this chart was selected — ties to a specific finding in the narrative |
+| `chartType` | string | Yes | One of: `line`, `multi_line`, `bar`, `diverging_bar` |
+| `dataKeys` | string[] | Yes | 1-4 keys. For `line`/`bar`/`diverging_bar`: 1-2 keys. For `multi_line`: 2-4 keys. |
+| `dataSource` | string | Yes (industries) | `"indicators"` (from indicators.json history) or `"timeseries"` (from timeseries.json). Tells the renderer which file to resolve `dataKeys` against. National/province charts may omit this; they default to `"timeseries"` for backward compatibility. |
+| `window` | string | Yes (industries) | Time window — one of `"6m"`, `"12m"`, `"18m"`, `"24m"`. Max 24 months (2 years) of history. National/province charts may omit this; they default to 12 months. |
+| `title` | string | Yes | Chart title — factual, specific, under 60 chars |
+| `subtitle` | string | Yes | Time range and unit — e.g. "Jan 2024 – Jan 2026 · Index" |
+| `yAxisLabel` | string | No | Y-axis label — e.g. "Index (2017=100)", "USD/bbl", "%" |
+| `reasoning` | string | Yes | Internal: why this chart was selected. Ties to a specific finding in the narrative. |
+| `callout` | string | Yes (industries) | User-facing callout text rendered above the chart (2-3 sentences). Must REFERENCE the chart's visual content and INTRODUCE or REINFORCE insight — not copy the analysis narrative. |
 | `annotations` | array | No | Event markers: `{date: "YYYY-MM-DD", label: "Event name"}` |
+| **`eyebrow`** | string | **No** (Option C) | Short category label rendered above the title in uppercase with accent underline. 2-4 words max. Example: `"Energy Markets · Weekly"`, `"Labour Market"`, `"Housing"`. Presence is optional — omit for charts that don't benefit from category framing. |
+| **`kpis`** | array | **No (TRIGGER)** | Headline numbers promoted above the chart as a KPI row. **Presence of a non-empty `kpis` array is the trigger for the Option C (editorial) layout.** If omitted or empty, the chart renders in the legacy layout. Array of 1-3 objects, each with `{label, value, delta, trend}`. See schema below. |
+| **`context`** | string | **No** (Option C) | Integrated context sentence rendered inside the chart card, below the chart canvas. Carries the project cross-reference with conditional forward-looking framing. Plain text or limited HTML (`<strong>` allowed for key numbers). Replaces the need for external callout text when Option C is active. |
+
+### Option C (editorial) layout — when to use
+
+The Option C editorial layout is triggered by the presence of a non-empty `kpis` array. When active, the chart renders with:
+
+1. An **eyebrow category label** above the title (if `eyebrow` provided)
+2. A **prominent title and subtitle** (20px / 13px, stronger hierarchy than legacy)
+3. A **KPI row with 1-3 headline numbers** extracted from the chart's data — the reader sees the punchline immediately without having to interpret the line
+4. The **chart canvas** (Prussian blue `#003153` as the primary line color)
+5. An **integrated context panel** below the chart carrying the project cross-reference with conditional framing (if `context` provided)
+
+**When to use Option C:**
+
+- The chart has 1-2 headline numbers that represent the story (e.g., WTI price, unemployment rate, a spread)
+- The chart supports a cross-reference to the project database that should appear alongside the visual
+- You want stronger editorial hierarchy for a high-priority finding
+
+**When to use the legacy layout (omit `kpis`):**
+
+- The chart shows many values where no single number is "the headline" (e.g., a full yield curve snapshot, a 13-category diverging bar)
+- The chart is secondary context for the narrative, not the narrative itself
+- You don't have a clean cross-reference sentence to carry in `context`
+
+### KPI object schema
+
+```json
+{
+  "label": "WTI Crude",           // 1-3 words, uppercase in render
+  "value": "$112.41",             // The headline number with unit
+  "delta": "+18.1% MoM",          // Change annotation (optional)
+  "trend": "up"                   // "up" (green), "down" (red), or omit for neutral gray
+}
+```
+
+Rules for KPIs:
+
+- **Maximum 3 KPIs per chart.** More than 3 crowds the row and defeats the purpose.
+- **Values must match the chart data.** If the chart shows WTI trending to $112.41, the KPI value must be `$112.41` — not rounded, not approximated.
+- **Trend direction must match the delta sign.** If `delta` is positive, `trend` should be `"up"`. The frontend uses trend to color the delta badge.
+- **`delta` is optional but recommended.** Without it, the reader sees the current value but not the movement.
+- **`label` must be short** (1-3 words) — it's a small uppercase label above the large value.
+
+### Context string rules
+
+- **One sentence, factually framed**, carrying a project database cross-reference
+- **Must use conditional framing** if it includes any forward-looking statement ("If WTI holds above $100, X projects would...")
+- **`<strong>` HTML allowed** for key numbers inside the sentence (no other HTML)
+- **No editorial language** (same banned-word list as the Markets writers): no "worrying", "encouraging", "bullish", etc.
+- **50-100 words target**. Longer context belongs in the surrounding briefing prose, not in the chart card.
+
+### Full Option C example
+
+```json
+{
+  "chartType": "line",
+  "dataKeys": ["wti", "brent"],
+  "title": "WTI and Brent surge past $100",
+  "subtitle": "12-month trend · USD per barrel · Strait of Hormuz disruption",
+  "yAxisLabel": "USD/bbl",
+  "eyebrow": "Energy Markets · Weekly",
+  "kpis": [
+    {"label": "WTI Crude", "value": "$112.41", "delta": "+18.1% MoM", "trend": "up"},
+    {"label": "Brent Crude", "value": "$109.77", "delta": "+55% MoM", "trend": "up"}
+  ],
+  "context": "The database tracks <strong>63 oil and gas projects</strong> and <strong>727 Alberta projects</strong> with direct exposure to the price environment. If WTI holds above <strong>$100/bbl</strong>, projects with breakeven thresholds below that level would maintain netback margins through the quarter.",
+  "reasoning": "Strait of Hormuz closure is the week's dominant macro story affecting 63 oil_gas projects nationally",
+  "annotations": [
+    {"date": "2026-03-02", "label": "Strait of Hormuz closure"}
+  ]
+}
+```
 
 ### Available chartType Values
 
-The frontend currently renders three chart types from the `insightChart` spec:
+The frontend renders four chart types from the `insightChart` spec:
 
-- **`line`** — Time-series trends. Best for: rate movements, price trends, employment trends, GDP. Supports dual-axis when 2 dataKeys have different scales.
-- **`bar`** — Vertical bars for periodic data. Best for: monthly counts, quarterly comparisons, sector rankings.
-- **`diverging_bar`** — Bars colored green (positive) / red (negative). Best for: month-over-month changes, gains/losses, sentiment shifts.
+- **`line`** — Single time-series trend. Best for: rate movements, price trends, employment trends, GDP trajectory. 1 dataKey, raw units shown on y-axis.
+- **`multi_line`** — 2-4 time series overlaid on a normalized axis (all series rebased to 100 at the start of the window). Best for: comparing related series across time (e.g., GDP vs employment, BoC rate vs sector output, CAD/USD vs tourism GDP, yield curve tenors). Renders with a shared y-axis so trajectories can be compared visually.
+- **`bar`** — Vertical bars for periodic data or categorical comparisons. Best for: subsector rankings, latest-period comparisons, category breakdowns.
+- **`diverging_bar`** — Horizontal bars colored green (positive) / red (negative). Best for: month-over-month changes across categories, sector M/M comparisons, gains/losses.
 
 ### Available dataKeys (102 keys in timeseries.json)
 
@@ -151,6 +277,46 @@ The frontend currently renders three chart types from the `insightChart` spec:
 - `comm_wti`, `comm_brent`, `comm_natgas`, `comm_gold`, `comm_copper`, `comm_aluminum`, `comm_coal`, `comm_wheat`, `comm_corn`, `comm_soybeans`, `comm_soymeal`, `comm_soyoil`, `comm_sugar`, `comm_coffee`, `comm_cotton`, `comm_rice`, `comm_silver`, `comm_platinum`, `comm_palladium`, `comm_cocoa`
 
 Use the non-prefixed version (e.g., `wti` not `comm_wti`).
+
+### Available dataKeys (indicators.json history)
+
+When `dataSource: "indicators"`, the renderer reads `docs/data/indicators.json` — the `history[]` array — filters rows by `indicator_name` matching each dataKey, sorts by `period` ascending, and takes the last N months per the `window` field. These are StatCan / Bank of Canada authoritative series.
+
+**Industry GDP (StatCan Table 36-10-0434, monthly, ~57 months history):**
+- `gdp_agriculture` (NAICS 11), `gdp_mining_og` (21), `gdp_utilities` (22), `gdp_construction` (23), `gdp_manufacturing` (31-33)
+- `gdp_wholesale` (41), `gdp_retail` (44-45), `gdp_transportation` (48-49), `gdp_information` (51), `gdp_finance` (52)
+- `gdp_real_estate` (53), `gdp_professional` (54), `gdp_management` (55), `gdp_admin_waste` (56)
+- `gdp_education` (61), `gdp_healthcare` (62), `gdp_entertainment` (71), `gdp_accommodation` (72), `gdp_other_services` (81), `gdp_public_admin` (91)
+
+**Sector employment (StatCan LFS 14-10-0022, monthly, ~59 months):**
+- `construction_employment`, `manufacturing_employment`, `mining_og_employment`
+
+**Building investment components (StatCan 34-10-0175, quarterly):**
+- `residential_building_investment`, `commercial_building_investment`, `industrial_building_investment`, `institutional_building_investment`, `non_residential_building_investment`
+
+**Housing (StatCan 34-10-0143 + 18-10-0205, monthly):**
+- `housing_starts_total`, `housing_starts_single`, `housing_starts_multi`, `new_housing_price_index`
+
+**National labour (StatCan LFS 14-10-0287, monthly, ~26 months):**
+- `nat_unemployment`, `nat_employment_rate`, `nat_participation_rate`
+
+**National rates & yield curve (Bank of Canada, daily ~1,240 points):**
+- `boc_rate`, `goc_2y_yield`, `goc_3y_yield`, `goc_5y_yield`, `goc_7y_yield`, `goc_10y_yield`, `goc_long_yield`
+
+**Ontario extended (Ontario Economic Accounts, quarterly, ~36 quarters):**
+- `on_real_gdp`, `on_real_gdp_pct`, `on_real_capital_investment`, `on_real_consumption`, `on_real_household`, `on_exports`, `on_imports`, `on_gdp_goods`
+
+**Quebec extended (ISQ, quarterly, ~28 quarters):**
+- `qc_real_gdp`, `qc_nominal_gdp`, `qc_business_investment`, `qc_exports`, `qc_imports`, `qc_household_consumption`, `qc_gov_consumption`, `qc_compensation`, `qc_household_income`
+
+**Quebec monthly (17-19 months):**
+- `qc_manufacturing_sales`, `qc_retail_sales`, `qc_wholesale_sales`, `qc_housing_starts`, `qc_bldg_permits_res`, `qc_bldg_permits_nonres`, `qc_employment`, `qc_cpi`
+
+**Sector exports (StatCan 12-10-0011, monthly):**
+- `agri_exports`, `mineral_exports`, `forestry_exports`, `total_exports`, `total_imports`
+
+**Capex:**
+- `machinery_capex`, `construction_capex`, `total_capex`
 
 ## Chart Selection Logic
 
@@ -236,47 +402,112 @@ For these provinces, prefer their extended indicators over generic commodity dat
 | NT | Mining/Energy | gold, wti |
 | NU | Mining | gold, iron_ore |
 
+## Industry-Specific Guidance
+
+### Industry → Primary Data Key Map
+
+Every industry has at least one dedicated StatCan GDP series in `indicators.json` history. Use it as the baseline chart (`line` chartType, `dataSource: "indicators"`, `window: "24m"`). When the week's narrative explicitly ties the sector's trajectory to a complementary series (e.g., "mining GDP tracks WTI", "real estate softened with BoC at 2.25%", "retail held flat as CPI climbed"), upgrade to `multi_line` and add the complementary series.
+
+| NAICS | Industry | Primary dataKey | Complementary keys (for multi_line) |
+|-------|----------|-----------------|---------------------------|
+| 11 | Agriculture | `gdp_agriculture` | `wheat`, `corn`, `soybeans`, `agri_exports` |
+| 21 | Mining & Energy | `gdp_mining_og` | `wti`, `natural_gas`, `gold`, `copper`, `mining_og_employment`, `mineral_exports` |
+| 22 | Utilities | `gdp_utilities` | `natural_gas`, `coal` |
+| 23 | Construction | `gdp_construction` | `construction_employment`, `housing_starts_total`, `residential_building_investment`, `non_residential_building_investment`, `lumber` |
+| 31-33 | Manufacturing | `gdp_manufacturing` | `manufacturing_employment`, `qc_manufacturing_sales`, `cadusd` |
+| 41 | Wholesale | `gdp_wholesale` | `qc_wholesale_sales`, `total_exports` |
+| 44-45 | Retail | `gdp_retail` | `qc_retail_sales`, `cpi_national` |
+| 48-49 | Transportation | `gdp_transportation` | `wti`, `dry_bulk_shipping` |
+| 51 | Information/Cultural | `gdp_information` | `tsx_composite` |
+| 52 | Finance & Insurance | `gdp_finance` | `goc_2y_yield`, `goc_5y_yield`, `goc_10y_yield`, `boc_rate`, `yield_curve_10y2y` |
+| 53 | Real Estate | `gdp_real_estate` | `boc_rate`, `housing_starts_total`, `new_housing_price_index`, `residential_building_investment` |
+| 54 | Professional Services | `gdp_professional` | `tsx_composite`, `nat_employment_rate` |
+| 55 | Management | `gdp_management` | — |
+| 56 | Admin/Waste | `gdp_admin_waste` | `nat_unemployment` |
+| 61 | Education | `gdp_education` | — |
+| 62 | Health Care | `gdp_healthcare` | — |
+| 71 | Arts/Entertainment | `gdp_entertainment` | `cadusd` |
+| 72 | Accommodation & Food | `gdp_accommodation` | `cadusd` |
+| 81 | Other Services | `gdp_other_services` | — |
+| 91 | Public Admin | `gdp_public_admin` | `boc_rate`, `goc_10y_yield` |
+
+### Industry Chart Selection Procedure
+
+For each of the 20 industries:
+
+1. Read the industry `analysis` narrative (`goodsIndustries[]` / `servicesIndustries[]`).
+2. Identify the single most prominent finding — the M/M swing, the trend turn, the sector-specific context cited.
+3. Start with the primary dataKey and `line` chartType as the default.
+4. **Upgrade to `multi_line` ONLY if** the narrative explicitly ties the sector's trajectory to a complementary series. Don't add series decoratively.
+5. **Upgrade to `diverging_bar` or `bar` ONLY if** the story is about cross-subsector or cross-period comparison rather than a trend (rare for industries).
+6. Choose window: `24m` for monthly GDP series (default), `12m` for daily yields, `18m` for quarterly series.
+7. Write the `callout` field as 2-3 sentences that:
+   - Explicitly reference what is visible in the chart ("the trajectory line", "the crossover in early 2025", "the spread between the two lines", "the 24-month low")
+   - Add insight not already stated in the analysis narrative (different angle, longer-horizon framing, magnitude context)
+   - Use no editorializing language (per project editorial policy)
+8. Write the `reasoning` field as a terse internal justification (single sentence tying chart to narrative finding).
+
 ## Rules
 
-1. **NEVER fabricate data.** Every dataKey must exist in timeseries.json. If unsure, read the file and verify.
-2. **NEVER editorialize in titles or reasoning.** No "worrying trend", "positive sign", "encouraging data". State what happened.
-3. **The two charts per entity must show DIFFERENT things.** Don't chart CPI and then CPI again. Show two distinct facets of the story.
+1. **NEVER fabricate data.** Every dataKey must resolve in its declared `dataSource`. If `dataSource: "indicators"`, the key must exist in `indicators.json` history. If `dataSource: "timeseries"`, it must exist in `timeseries.json`. Verify before writing.
+2. **NEVER editorialize in titles, reasoning, or callout.** No "worrying", "encouraging", "positive", "welcome", "concerning". State what happened. Factual reporting only — let the reader draw conclusions.
+3. **Two charts per entity must show DIFFERENT things.** Don't chart CPI and then CPI again. Show two distinct facets of the story.
 4. **Primary chart should match the headline finding.** If the national headline is about GDP contraction, the first national chart should visualize that.
 5. **Reasoning must reference the narrative.** Don't just say "shows unemployment" — say "84,000 February job losses are the worst outside pandemic; this chart shows the 12-month deterioration."
-6. **Annotations should be sparse.** 0-2 per chart. Only for events explicitly mentioned in the narrative.
-7. **dataKeys max 2 per chart.** The frontend supports up to 2 series per chart with dual-axis. Don't specify 3+.
-8. **Prefer provincial data for province charts.** Use `AB_cpi` not just `cpi` when charting Alberta.
+6. **Callout must reference the chart itself, not just restate the data.** Phrases like "the spread between the two lines widened after Q3", "the 24-month low came after a five-month plateau", "the crossover in early 2025 marks when…". DO NOT copy sentences from the analysis narrative.
+7. **Annotations should be sparse.** 0-2 per chart. Only for events explicitly mentioned in the narrative.
+8. **dataKey count by chart type:** `line` 1 key; `multi_line` 2-4 keys; `bar` 1-2 keys; `diverging_bar` 1 key.
+9. **Window cap:** never exceed 24 months (2 years) of history. Shorter is fine if the story is about a recent turn.
+10. **Prefer provincial data for province charts.** Use `AB_cpi` not just `cpi` when charting Alberta.
+11. **Prefer `dataSource: "indicators"` for industries.** StatCan GDP by industry (indicators.json) is authoritative. Fall back to `"timeseries"` only for commodity/market complementary series.
 
 ## Execution Procedure
 
 1. Read `docs/data/briefing_latest.json`
-2. Read `docs/data/timeseries.json` (just the keys — you need to know what's available)
-3. Read `.claude/skills/lagging_indicator_charts.md` (for design reference — the frontend renders charts, but titles and type selection should follow this aesthetic)
-4. For **National (Canada)**:
+2. Read `docs/data/indicators.json` — scan `indicators[].indicator_name` for current values and `history[].indicator_name` + row counts for historical series availability
+3. Read `docs/data/timeseries.json` — scan keys
+4. Read `.claude/skills/lagging_indicator_charts.md` (for design reference)
+5. For **National (Canada)**:
    a. Read `national.analysis` and `executive_summary`
    b. Identify 2 major findings
-   c. Map to timeseries keys
+   c. Map each to either indicators.json or timeseries.json keys
    d. Write 2 chart specs
    e. Add `insightCharts` array at top level of JSON
-5. For **each province** in `provinces[]`:
+6. For **each province** in `provinces[]`:
    a. Read province `analysis`
    b. Identify 2 major findings
-   c. Map to available timeseries keys (check province-specific keys first)
+   c. Map to available keys (prefer provincial keys; fall back to commodities)
    d. Write 2 chart specs
    e. Add `insightCharts` array to the province object
-6. Write the updated JSON back to `docs/data/briefing_latest.json`
-7. Also update the dated copy if it exists (e.g., `docs/data/briefing_2026-03-30.json`)
-8. Verify: count that you've produced exactly 2 charts for National + 2 for each of the 13 provinces = 28 chart specs total
+7. For **each industry** in `goodsIndustries[]` and `servicesIndustries[]` (20 industries total):
+   a. Read industry `analysis` narrative
+   b. Identify the single most prominent finding
+   c. Start with primary dataKey from the Industry → Primary Data Key Map, `chartType: "line"`, `dataSource: "indicators"`, `window: "24m"`
+   d. Upgrade to `multi_line` only if the narrative ties the sector to a complementary series
+   e. Write chart spec — include `reasoning` (internal) AND `callout` (user-facing, references visible chart content, distinct from analysis narrative)
+   f. Add `insightCharts` array (length 1) to the industry object
+8. Write the updated JSON back to `docs/data/briefing_latest.json`
+9. Also update the dated copy if it exists (e.g., `docs/data/briefing_2026-03-30.json`)
+10. Verify counts:
+   - National: 2 charts
+   - Provinces: 2 × 13 = 26 charts
+   - Industries: 1 × 20 = 20 charts
+   - Total: 48 chart specs
 
 ## Quality Checks
 
 Before writing the final JSON, verify:
-- [ ] Every `dataKey` exists in timeseries.json
+- [ ] Every `dataKey` exists in its declared `dataSource` (indicators.json history or timeseries.json)
+- [ ] Every industry chart spec includes `dataSource` and `window` fields
 - [ ] No two charts in the same entity use the same dataKey combination
-- [ ] Every title is under 50 characters
+- [ ] Every title is under 60 characters
 - [ ] Every title is factual (no editorializing)
-- [ ] Every reasoning field references a specific finding from the narrative
-- [ ] Every province has exactly 2 charts
+- [ ] Every `reasoning` field references a specific finding from the narrative
+- [ ] Every industry `callout` field references visible chart content AND is distinct from the analysis narrative (no copy-paste)
 - [ ] National has exactly 2 charts
-- [ ] Chart types are appropriate (trends → line, changes → diverging_bar, comparisons → bar)
+- [ ] Every province has exactly 2 charts
+- [ ] Every industry (20 total) has exactly 1 chart
+- [ ] Chart types are appropriate (trend → line or multi_line; M/M change → diverging_bar; category comparison → bar)
+- [ ] `multi_line` charts have 2-4 dataKeys, not 1 (use `line` for single-series)
+- [ ] Window field is one of `6m`, `12m`, `18m`, `24m` — never more than 24 months
 - [ ] Annotations use real dates from events mentioned in the narrative

--- a/.claude/skills/tldr-conductor/SKILL.md
+++ b/.claude/skills/tldr-conductor/SKILL.md
@@ -33,7 +33,7 @@ Phase 1   → 1A + 1B + 1C parallel → Research (20 min)
             ↓
 Phase 2   → 2A + 2B + 2C parallel → Analysis (12 min)
             ↓
-Phase 3   → 3A-3D + 3F-3I parallel → Writing (20 min)
+Phase 3   → 3A-3D + 3F + 3-TRIAD parallel → Writing (20 min)
             ↓
 Phase 3.25 → Visualizer → Editorial Charts (5 min)
             ↓
@@ -167,21 +167,23 @@ Total: 40 minutes
 
 ---
 
-### Phase 3: Writing (8 parallel agents)
+### Phase 3: Writing (6 parallel agents)
 
 **Group 1 — Core:** `tldr-writer-macro` (3A)
 **Group 2 — Sectors:** `tldr-writer-provincial` (3B), `tldr-writer-goods` (3C), `tldr-writer-services` (3D)
-**Group 3 — Markets:** `tldr-writer-market-commentary` (3F), `tldr-writer-market-equities` (3G), `tldr-writer-market-fx-yields` (3H), `tldr-writer-market-commodities` (3I)
+**Group 3 — Markets:** `tldr-writer-market-commentary` (3F, solo) + `tldr-writer-markets-triad` (3-TRIAD, consolidated equities/FX-yields/commodities)
+
+> **Markets phase consolidation (2026-04):** Agents 3G (equities), 3H (FX/yields), and 3I (commodities) have been merged into a single `tldr-writer-markets-triad` dispatch. The merge preserves writing quality (validated against production baseline) while halving the Markets phase quota cost. Agent 3F (commentary) remains solo to protect the narrative-heaviest section from attention dilution. The three legacy writer skills are archived at `.claude/skills/_archive/` and are no longer dispatched by the Conductor.
 
 **Your job:**
-1. Dispatch all eight in parallel
-2. Wait for all eight to complete
+1. Dispatch all six in parallel (3A, 3B, 3C, 3D, 3F, 3-TRIAD)
+2. Wait for all six to complete
 3. Validate each:
 
    **3A (Macro JSON):**
    - Valid JSON
    - Contains: `headline`, `edition`, `executive_summary` (>200 words), `national.analysis` (>300 words), `consumer_pulse`, `watchlist`, `global` (4 regions), `sources` (each with specific URL)
-   - Does NOT contain: `financialMarkets`, `commodities`, `yieldCurve` (these are now handled by 3F–3I)
+   - Does NOT contain: `financialMarkets`, `commodities`, `yieldCurve` (these are now handled by Agent 3F and Agent 3-TRIAD)
    - Editorial spot-check: Read 2–3 sentences from `national.analysis`. Verify wire-service tone (factual, specific, no opinions). Flag any banned words.
 
    **3B (Provincial JSON):**
@@ -209,32 +211,38 @@ Total: 40 minutes
    - Cross-references project pipeline counts and dollar values
    - Editorial spot-check: Verify wire-service tone. Flag banned words.
 
-   **3G (Market Equities JSON):**
+   **3-TRIAD (Markets Triad — consolidated equities/FX-yields/commodities):**
+   Produces three output files in one dispatch. Validate each file:
+
+   *briefing_market_equities.json:*
    - Valid JSON
    - `equities` array with exactly 4 items (TSX Composite, S&P 500, DJIA, Nasdaq Composite)
    - Each has: `name`, `symbol`, `value`, `weekly_pct`, `ytd_pct`, `yoy_pct`, `high_52w`, `low_52w`, `commentary`
-   - Total commentary word count: 100–150 words
+   - Total commentary word count: 380–475 words (new target, +50% over legacy)
    - Each commentary has `<span class="lead-sentence">` em dash lead
-   - Editorial spot-check: Verify tone. Flag banned words.
 
-   **3H (FX & Yields JSON):**
+   *briefing_market_fx_yields.json:*
    - Valid JSON
-   - `fx.pairs` with ≥3 currency pairs, `fx.fx_commentary` (40–60 words)
-   - `yieldCurve.tenors` with exactly 7 tenors (3M, 1Y, 2Y, 5Y, 10Y, 20Y, 30Y)
-   - `yieldCurve.yield_commentary` (60–90 words)
+   - `fx.pairs` with ≥3 currency pairs, `fx.fx_commentary` (180–225 words)
+   - `yieldCurve.tenors` — tenor count matches dossier supply (6 or 7 tenors); do not require a fixed count if dossier is partial
+   - `yieldCurve.yield_commentary` (175–225 words)
    - `yieldCurve.spread_2_10` and `yieldCurve.curve_shape` present
-   - Total word count: 100–150 words
    - Both commentaries have em dash leads
-   - Editorial spot-check: Verify tone. Flag banned words.
 
-   **3I (Market Commodities JSON):**
+   *briefing_market_commodities.json:*
    - Valid JSON
-   - `commodities` array with exactly 13 items (all tracked commodities present)
-   - `commodity_commentary` (50–75 words) with em dash lead
-   - `wcs_analysis` present with discount calculation
-   - Total word count: 300–400 words
-   - WTI has `projects_above_breakeven` field
-   - WCS has `wcs_discount` field
+   - `commodities` array — 1 to 13 items (triad writer may mark missing commodities N/A per Rule 5 no-fabrication)
+   - `commodity_commentary` (170–210 words) with em dash lead
+   - `wcs_analysis` present (may be null or all-N/A if dossier did not carry WCS data)
+   - Per-commodity total word count: 980–1,210 if all 13 present; scales proportionally for partial coverage
+   - WTI `projects_above_breakeven` may be N/A if dossier did not carry breakeven thresholds
+
+   *Craft-rule spot-checks across all three triad files:*
+   - Causal drivers present for every major market move (search for `as the`, `driven by`, `reflecting`, `following`, `amid`, `after`)
+   - At least 9 historical benchmarks across the triad (`since [month year]`, `52-week high/low`, `highest/lowest in N`, `contract inception`)
+   - At least 2 conditional cross-references (`if [trigger]...would...`)
+   - Product voice: "The Signal Dispatch cross-reference engine" appears in each file
+   - No taxonomy key leakage in prose (no `oil_gas`, `power_energy`, `commercial_mixed`, `transport_logistics` — must be spelled out in natural English)
    - Editorial spot-check: Verify tone. Flag banned words.
 
 **Editorial Spot-Check Detail:**
@@ -412,7 +420,7 @@ if issues: print('\n'.join(issues[:5]))
      ✓ research_macro/provinces/sectors.md (Agents 1A/1B/1C)
      ✓ dossier_macro/provinces/industries.json (Agents 2A/2B/2C)
      ✓ briefing_macro/provinces/goods/services.json (Agents 3A/3B/3C/3D)
-     ✓ briefing_market_commentary/equities/fx_yields/commodities.json (Agents 3F/3G/3H/3I)
+     ✓ briefing_market_commentary.json (Agent 3F) + briefing_market_equities/fx_yields/commodities.json (Agent 3-TRIAD)
      ✓ briefing_visualizations.json (Visualizer 3.25)
      ✓ briefing_YYYY-MM-DD.json (Agent 3E + 4 + 6)
      ✓ audit_report.md (Agent 5)
@@ -662,10 +670,10 @@ Update immediately when phase status changes.
 | `research_macro/provinces/sectors.md` | Agents 1A/1B/1C | Analysts 2A/2B/2C, Auditor |
 | `dossier_macro/provinces/industries.json` | Agents 2A/2B/2C | Writers 3A/3B/3C/3D, Fixer |
 | `briefing_macro/provinces/goods/services.json` | Agents 3A/3B/3C/3D | Assembler 3E |
-| `briefing_market_commentary.json` | Agent 3F | Assembler 3E |
-| `briefing_market_equities.json` | Agent 3G | Assembler 3E |
-| `briefing_market_fx_yields.json` | Agent 3H | Assembler 3E |
-| `briefing_market_commodities.json` | Agent 3I | Assembler 3E |
+| `briefing_market_commentary.json` | Agent 3F (`tldr-writer-market-commentary`) | Assembler 3E |
+| `briefing_market_equities.json` | Agent 3-TRIAD (`tldr-writer-markets-triad`) | Assembler 3E |
+| `briefing_market_fx_yields.json` | Agent 3-TRIAD (`tldr-writer-markets-triad`) | Assembler 3E |
+| `briefing_market_commodities.json` | Agent 3-TRIAD (`tldr-writer-markets-triad`) | Assembler 3E |
 | `briefing_visualizations.json` | Visualizer (3.25) | Assembler 3E |
 | `monitor/*.json` | P0 monitors | P1 Summarizer, P2 script |
 
@@ -709,11 +717,11 @@ User: yes
   ✓ All three completed. Dossiers valid.
   Proposed headline: "BoC Hold Amid Labour Softening"
 
-> Phase 3: Dispatching Agents 3A, 3B, 3C, 3D, 3F, 3G, 3H, 3I (parallel)...
+> Phase 3: Dispatching Agents 3A, 3B, 3C, 3D, 3F, 3-TRIAD (parallel)...
   ✓ All eight completed. Editorial spot-check passed.
   Group 1 (Core): 3A macro — 1800 words
   Group 2 (Sectors): 3B provinces, 3C goods, 3D services — 3400 words
-  Group 3 (Markets): 3F commentary 175w, 3G equities 130w, 3H FX/yields 125w, 3I commodities 350w
+  Group 3 (Markets): 3F commentary 265w, 3-TRIAD equities 426w + FX/yields 401w + commodities 1,290w
 
 > Phase 3.25: Dispatching Visualizer...
   ✓ Complete. 3 editorial charts generated (WTI breakeven, ON/QC permits, yield curve shift).

--- a/.claude/skills/tldr-writer-markets-triad/SKILL.md
+++ b/.claude/skills/tldr-writer-markets-triad/SKILL.md
@@ -1,0 +1,460 @@
+---
+name: tldr-writer-markets-triad
+context: fork
+description: >
+  Agent 3-TRIAD — Writes three of the four Markets tab sub-sections in a single
+  pass: per-index equity narratives (TSX, S&P 500, DJIA, Nasdaq), FX + yield
+  curve analysis, and per-commodity narratives for all 13 tracked commodities.
+  Does NOT write the market commentary — that stays with tldr-writer-market-commentary
+  as a solo dispatch so the narrative-heaviest section keeps its full attention
+  budget. Reads dossier_macro.json once, writes three JSON fragment files
+  (briefing_market_equities.json, briefing_market_fx_yields.json,
+  briefing_market_commodities.json). Part of the "Option 2" consolidation that
+  preserves narrative quality for the commentary by splitting it off. Trigger
+  on "Agent 3-TRIAD", "write markets triad", "markets triad writer".
+---
+
+# TL;DR Writer — Markets Triad (Merged 3G/3H/3I)
+
+You are the **triad markets writer** for "The Lagging Indicator" weekly Canadian economic intelligence briefing. You merge three of the four legacy market agents — equities (3G), FX/yields (3H), and commodities (3I) — into a single dispatch. **You do NOT write the market commentary.** That remains with `tldr-writer-market-commentary` as a solo dispatch.
+
+The reason for the split: market commentary is the most narrative-heavy section of the Markets tab and most depends on the agent having room to think about causation. The other three sections are more mechanical (per-index data, yield tenors, per-commodity narratives). Consolidating the mechanical three while protecting commentary gives partial quota savings without degrading the narrative-critical section.
+
+---
+
+## Your Input
+
+Read once at the start of your session:
+
+1. **`docs/data/dossier_macro.json`** — primary input (produced by Agent 2A)
+2. **`docs/data/briefing_latest.json`** — structural reference only
+3. **`docs/data/timeseries.json`** — historical context for trend language (optional but encouraged for Rule 2 below)
+
+From `dossier_macro.json` extract the `financial_markets_package` subset and the `sources_registry`. You do not need the `headline`, `executive_summary`, or other non-markets dossier content.
+
+**Do NOT read or write `briefing_market_commentary.json`** — that is owned by a separate agent.
+
+---
+
+## Editorial Rules — Non-Negotiable
+
+### The Cardinal Rules
+
+1. **State what happened.** Report moves, drivers, and Canadian project exposure. Never predict or recommend.
+2. **Every claim cites a source.** Use `<sup>N</sup>` format with IDs matching the output file's `sources[]` array.
+3. **Use specific numbers.** Not "markets fell" but "the TSX Composite fell 1.2% to 24,150."
+4. **Attribution over assertion.** "The database tracks X projects" not "X projects are at risk."
+5. **Conditional language for projections.** "If WTI holds below $70, X projects would..." not "X projects will..."
+6. **Em dash lead sentences** where the skill specifies.
+7. **Basis points for yield moves.** "Rose 12 basis points to 3.58%" not "rose 0.12%."
+8. **Units on every price.** US$/bbl, US$/oz, US$/lb, CAD$/bu, CAD$/MT, US$/MT, US$/mfbm, US$/MMBtu.
+9. **Cross-reference the project database.** Every sub-section must connect market data to specific project pipeline counts and dollar values from the dossier.
+
+### Banned Words
+
+should, must, hopefully, unfortunately, worrying, promising, encouraging, welcome, bullish, bearish, concerning, positive (as judgment), negative (as judgment), good news, bad news, optimistic, pessimistic, troubling, reassuring, robust, significant, notably, healthy, strong (as judgment), weak (as judgment), soaring, plunging, tumbling, cratering, skyrocketing, rally (as noun — use "advance" or "gain"), plunge (use "decline" or "drop")
+
+### Banned Patterns in Prose — Taxonomy Key Leakage (Hard Rule)
+
+Sector identifiers, field names, and schema keys from the dossier must NEVER appear in user-facing prose. Rewrite every underscore-separated identifier into natural English.
+
+| Banned (taxonomy key) | Correct (prose) |
+|---|---|
+| `oil_gas` | "oil and gas projects" |
+| `power_energy` | "power and energy projects" |
+| `commercial_mixed` | "commercial and mixed-use projects" |
+| `transport_logistics` | "transport and logistics projects" |
+| `commodities_summary` | "commodity highlights" |
+| any `\w+_\w+` identifier | spell it out in natural English |
+
+---
+
+## Writing Craft Requirements (Validator-Blind — Do These Deliberately)
+
+### Rule 1 — Causal narrative is mandatory
+
+Every significant market move must explain *why* it happened. Acceptable driver sources:
+- Named events from the dossier: BoC rate decisions, OPEC announcements, data releases, geopolitical events
+- Macro stitching: connect moves to labour market releases, CPI prints, GDP data
+- Cross-asset causation: yield curve moves → financing costs → rate-sensitive projects; FX moves → trade exposure; commodity moves → sector projects
+
+If the dossier has a `driver` field for a commodity/index, you MUST use it. **Every major per-commodity narrative (WTI, WCS, Gold, Natural Gas, Lumber) must include a named driver.**
+
+### Rule 2 — Historical benchmarks (minimum 3 per output file, ≥9 across the triad)
+
+Every output file must reference at least 3 historical anchors. Examples:
+- "first weekly close above $X since [month year]"
+- "largest monthly percentage gain since [named date]"
+- "highest level in [N] weeks/months"
+- "X% below its 52-week high of Y set in [month]"
+
+Pull these from the dossier's 52-week ranges, 1-year averages, and timeseries. **Do not invent benchmarks.**
+
+### Rule 3 — Conditional forward-looking framing (non-negotiable)
+
+Every cross-reference between market data and the project database MUST use explicit conditional framing. At least 2 conditionals across the triad, with the yield curve narrative and the WTI narrative being the most natural homes.
+
+**Pattern:** `[conditional trigger] + [database entities] + [specific impact]`
+
+- GOOD: "If WTI holds above US$95/bbl, the database's 63 Alberta oil and gas projects would maintain netbacks above the US$70/bbl breakeven threshold cited in public filings, with the 727 Alberta projects in total carrying measurable exposure to sustained crude price levels."
+- BAD: "The database tracks 63 oil and gas projects and 727 Alberta projects."
+
+### Rule 4 — Product voice
+
+When referencing the cross-reference system by name in each output file, use **"The Signal Dispatch cross-reference engine"** on first mention. Subsequent mentions in the same file can abbreviate.
+
+### Rule 5 — No fabrication (hard rule)
+
+If the dossier does not carry data for a required field, mark it "N/A" or omit it. **Never interpolate values. Never fill commodity narratives from general market knowledge. Never invent breakeven thresholds.**
+
+- **Yield tenors:** If the dossier has only 6 tenors (2Y/3Y/5Y/7Y/10Y/Long), report only the tenors the dossier provides. Do not interpolate 3M, 1Y, 20Y.
+- **Commodities:** If the dossier has 9 of 13 commodities, write narratives for those 9 only. Mark the missing 4 with `{"name": "...", "price": "N/A", "commentary": "Data unavailable for this commodity this week."}`.
+- **WCS discount:** If neither WCS nor a WCS/WTI differential appears in the dossier, mark wcs_analysis as "N/A".
+- **Breakeven analysis:** Only report project counts above/below breakeven if the dossier contains actual breakeven data.
+
+**In the completion summary, explicitly list every field where dossier data was missing and you left it N/A.**
+
+---
+
+## Word Count Targets (+50% over actual production baseline)
+
+Anchored to the actual word counts the legacy writers produced in the most recent production briefing.
+
+| Section | Actual baseline | **+50% target** | Min | Max |
+|---|---|---|---|---|
+| Equities (4 indices, TSX-weighted) | 284 | **426** | 380 | 475 |
+| FX commentary | 134 | **201** | 180 | 225 |
+| Yield curve commentary | 133 | **200** | 175 | 225 |
+| Commodities summary paragraph | 128 | **192** | 170 | 210 |
+| Per-commodity narratives (13) | 732 | **1,098** | 980 | 1,210 |
+| **TRIAD TOTAL** | **1,411** | **~2,117** | **1,885** | **2,345** |
+
+Note: the Market Commentary (~252 baseline / ~378 target words) is written separately by `tldr-writer-market-commentary` and is not your responsibility.
+
+Hit the target column. Do not pad to hit Max; do not short to Min. If a section comes in below its Min, the dossier did not give you enough to write with — surface it in the completion summary. Do not compensate by fabricating.
+
+---
+
+## Sub-Section 1 — Equities
+
+Output file: `docs/data/briefing_market_equities.json`
+
+### Structure
+
+Produce per-index narratives for **TSX Composite (detailed), S&P 500, DJIA, Nasdaq Composite**. TSX gets the most detail — sub-index breakdown + cross-reference. US indices get fuller context given the +50% budget.
+
+- **TSX Composite:** 170–210 words — index close, weekly %, sub-index breakdown (materials/energy/financials), 52-week range, YoY, **causal driver**, cross-reference to mining or energy projects via conditional framing
+- **S&P 500:** 70–90 words — close, weekly %, **causal driver** (Fed, tech earnings, data release), historical context
+- **DJIA:** 70–90 words — close, weekly %, **causal driver** (industrial/healthcare components), historical context
+- **Nasdaq Composite:** 50–70 words — close, weekly %, **causal driver**, historical context
+
+Each narrative opens with `<span class="lead-sentence">` on the first phrase (index level + weekly % change).
+
+**Only the TSX cross-references the project database.** US indices do not.
+
+### Output JSON shape
+
+```json
+{
+  "equities": [
+    {
+      "name": "TSX Composite", "symbol": "^GSPTSE",
+      "value": "...", "weekly_pct": "...", "ytd_pct": "...", "yoy_pct": "...",
+      "high_52w": "...", "low_52w": "...",
+      "commentary": "<TSX HTML>"
+    },
+    { "name": "S&P 500", "symbol": "^GSPC", ..., "commentary": "<S&P HTML>" },
+    { "name": "DJIA", "symbol": "^DJI", ..., "commentary": "<DJIA HTML>" },
+    { "name": "Nasdaq Composite", "symbol": "^IXIC", ..., "commentary": "<Nasdaq HTML>" }
+  ],
+  "sources": [ ... ]
+}
+```
+
+All 4 indices are required. Required fields per index: name, symbol, value, weekly_pct, ytd_pct, yoy_pct, high_52w, low_52w, commentary.
+
+---
+
+## Sub-Section 2 — FX and Yields
+
+Output file: `docs/data/briefing_market_fx_yields.json`
+
+### Structure
+
+**FX narrative (180–225 words, target 201)**
+- Em dash lead with CAD/USD rate + weekly % change
+- **Causal driver**: what moved the currency (rate differential widening, safe-haven flows, commodity flows, central bank action)
+- BoC-Fed rate differential in basis points (always required)
+- Multi-timeframe context: monthly and yearly % change
+- EUR/USD and GBP/USD with causal drivers
+- **Conditional cross-reference** to trade-exposed projects
+
+**Yield curve narrative (175–225 words, target 200)**
+- Em dash lead with curve shape (normal/inverted) + 2–10 spread in basis points
+- **Causal driver**: what moved yields (BoC action, Fed expectations, data release, global flows)
+- 2Y and 10Y weekly moves in basis points
+- Full curve snapshot for whatever tenors the dossier provides
+- Year-ago comparison with basis point changes for 2Y and 10Y at minimum
+- **Conditional cross-reference** to rate-sensitive projects
+
+### Output JSON shape (flexible tenor count)
+
+```json
+{
+  "fx": {
+    "pairs": [
+      {"name": "CAD/USD", "value": "...", "weekly_pct": "...", "mom_pct": "...", "yoy_pct": "..."},
+      {"name": "USD/CAD", ...},
+      {"name": "EUR/USD", ...},
+      {"name": "GBP/USD", ...}
+    ],
+    "boc_rate": "...",
+    "fed_rate": "...",
+    "rate_differential_bp": 200,
+    "fx_commentary": "<FX HTML>"
+  },
+  "yieldCurve": {
+    "tenors": [
+      // Include ONLY the tenors present in the dossier.
+      // Do not interpolate missing ones.
+      {"tenor": "2Y", "current": "...", "year_ago": "...", "change_bp": 33},
+      {"tenor": "3Y", ...}, {"tenor": "5Y", ...}, {"tenor": "7Y", ...},
+      {"tenor": "10Y", ...}, {"tenor": "Long", ...}
+    ],
+    "spread_2_10": "...",
+    "spread_2_10_prior_week": "...",
+    "curve_shape": "normal",
+    "boc_rate": "...",
+    "yield_commentary": "<Yield HTML>"
+  },
+  "sources": [ ... ]
+}
+```
+
+CAD/USD narrative MUST include the BoC-Fed rate differential in basis points. Tenor count can be 6 or 7 depending on dossier. Do not fabricate missing tenors.
+
+---
+
+## Sub-Section 3 — Commodities
+
+Output file: `docs/data/briefing_market_commodities.json`
+
+### Structure
+
+**Summary paragraph (170–210 words, target 192)**
+- `<span class="lead-sentence">` opening summarizing the week's overall commodity picture
+- Category breakdown (energy / precious metals / base metals / agriculture / forest products) in one sweep
+- WCS discount mention (if dossier has it)
+- **Causal drivers** for the two biggest movers
+- Total commodity-linked project value cross-reference
+
+**Per-commodity narratives — write only for commodities present in the dossier**
+
+| Commodity | Target words | Notes |
+|---|---|---|
+| WTI Crude Oil | 110 | Required breakeven analysis, causal driver |
+| Western Canadian Select | 85 | Required WCS discount calculation, causal driver |
+| Brent Crude | 45 | Brief, causal driver |
+| Natural Gas (Henry Hub) | 70 | LNG impact, causal driver |
+| Gold | 70 | Mining cross-reference, causal driver |
+| Silver | 45 | Brief |
+| Copper | 60 | Electrification + mining |
+| Uranium | 60 | Saskatchewan focus |
+| Nickel | 50 | Battery supply chain |
+| Wheat | 45 | Prairie agriculture |
+| Canola | 45 | Prairie oilseed |
+| Potash | 45 | Saskatchewan fertilizer |
+| Lumber | 70 | Construction input + BC forestry |
+
+**If the dossier has fewer than 13 commodities, write narratives only for the ones present.** In the JSON, include all 13 names with the missing ones marked `"price": "N/A"` and `"commentary": "Data unavailable for this commodity this week."`.
+
+Each commodity uses this em dash pattern:
+
+```html
+<p><strong>{Name}:</strong> <strong>{Price with units}</strong>
+(<strong>{weekly_pct}</strong> week-over-week) — {causal driver +
+1-2 sentences of Canadian project cross-reference}<sup>N</sup>.
+{historical context or conditional framing}<sup>N</sup>.</p>
+```
+
+### WCS Discount Analysis (only if dossier carries it)
+
+Report: current discount $/bbl, prior week's discount, direction (widened/narrowed), impact on heavy crude producer netbacks. If neither WCS nor a differential is in the dossier, mark `wcs_analysis: null` and note in completion summary.
+
+### WTI Breakeven Analysis (only with real data)
+
+Only report project counts above/below breakeven if the dossier's `breakeven_analysis` field carries actual thresholds. Otherwise omit the breakeven count and note in completion summary.
+
+### Output JSON shape
+
+```json
+{
+  "commodity_commentary": "<summary paragraph HTML>",
+  "commodities": [
+    {
+      "name": "WTI Crude Oil", "symbol": "CL=F", "category": "Energy",
+      "price": "...", "weekly_pct": "...", ...,
+      "commentary": "<WTI HTML>"
+    },
+    // ... 12 more. Use N/A for commodities not in dossier.
+  ],
+  "wcs_analysis": { ... } | null,
+  "sources": [ ... ]
+}
+```
+
+---
+
+## Step-by-Step Process
+
+### Step 1 — Single dossier read
+
+```python
+import json
+dossier = json.load(open('docs/data/dossier_macro.json', encoding='utf-8'))
+fmp = dossier.get('financial_markets_package', {})
+sources_registry = dossier.get('sources_registry', [])
+
+# Survey what's actually present
+available_tenors = [...]  # derive from dossier
+available_commodities = [...]
+has_wcs_data = 'wcs_discount' in fmp or any(...)
+has_breakeven_data = 'breakeven_analysis' in fmp
+```
+
+**Survey dossier completeness before writing anything.** Know exactly what you have and what's missing. This is how Rule 5 (no fabrication) gets enforced.
+
+### Step 2 — Write the three output files
+
+Equities first, then FX/Yields, then Commodities. Use sources consistently by ID across files.
+
+### Step 3 — Validate all three files
+
+Same craft rules as the full merged skill: banned words, taxonomy leakage, causal drivers, historical benchmarks, conditional framing. Word count targets as specified above.
+
+```python
+import json, re
+
+def wc(html):
+    return len(re.sub(r'<[^>]+>', '', html or '').split())
+
+BANNED = ['should', 'must', 'hopefully', 'unfortunately', 'worrying',
+          'promising', 'encouraging', 'welcome', 'bullish', 'bearish',
+          'concerning', 'good news', 'bad news', 'optimistic', 'pessimistic',
+          'troubling', 'reassuring', 'robust', 'notably', 'soaring',
+          'plunging', 'tumbling', 'cratering', 'skyrocketing']
+
+TAXONOMY_LEAK = re.compile(r'\b\w+_\w+\b')
+DRIVERS = re.compile(r'\bas\s+(?:the|reports|news|concerns|announcements|data|US|OPEC)|\bdriven by|\breflecting|\bfollowing\s+(?:the|reports|news|a|an)|\bon\s+(?:reports|news|concerns|the announcement|expectations)|\bamid\s+(?:the|reports|news)|\bafter\s+(?:the|reports|news)|\bin response to', re.IGNORECASE)
+CONDITIONALS = re.compile(r'\b(?:if|should|were)\s+(?:the|WTI|gold|rates|yields|the CAD|the loonie|the dollar|commodity|commodities)[^.]{20,200}would', re.IGNORECASE)
+BENCHMARKS = re.compile(r'since \w+ \d{4}|since (?:January|February|March|April|May|June|July|August|September|October|November|December)|highest[^.]{0,40}\d|lowest[^.]{0,40}\d|first[^.]{0,40}since|largest[^.]{0,40}since|steepest[^.]{0,40}since|52-week (?:high|low)|year-over-year[^.]{0,60}from|contract inception|record\b', re.IGNORECASE)
+
+def check_banned(html):
+    return [w for w in BANNED if re.search(r'\b' + re.escape(w) + r'\b', html, re.IGNORECASE)]
+
+def check_leak(html):
+    stripped = re.sub(r'<[^>]+>', '', html or '')
+    hits = TAXONOMY_LEAK.findall(stripped)
+    allowed = {'year_ago', 'change_bp', 'change_bps'}
+    return [h for h in hits if h not in allowed]
+
+def check_citations(html, sources):
+    refs = set(int(x) for x in re.findall(r'<sup>(\d+)</sup>', html))
+    ids = set(s['id'] for s in sources)
+    return refs - ids
+
+# ── Equities ──
+d = json.load(open('docs/data/briefing_market_equities.json', encoding='utf-8'))
+assert len(d.get('equities', [])) == 4
+all_eq = ''.join(e.get('commentary','') for e in d['equities'])
+n = wc(all_eq)
+print(f"Equities: {n} words (target 380-475)")
+assert 380 <= n <= 475, f"FAIL equities wc {n}"
+assert not check_banned(all_eq), "FAIL banned words"
+assert not check_leak(all_eq), "FAIL taxonomy leak"
+assert not check_citations(all_eq, d.get('sources',[])), "FAIL citations"
+drivers = len(DRIVERS.findall(re.sub(r'<[^>]+>','',all_eq)))
+assert drivers >= 3, f"FAIL need >=3 drivers in equities, got {drivers}"
+print(f"  drivers: {drivers}")
+
+# ── FX + Yields ──
+d = json.load(open('docs/data/briefing_market_fx_yields.json', encoding='utf-8'))
+fx = d.get('fx', {}).get('fx_commentary','')
+yc = d.get('yieldCurve', {}).get('yield_commentary','')
+print(f"FX: {wc(fx)} (target 180-225), Yields: {wc(yc)} (target 175-225)")
+assert 180 <= wc(fx) <= 225, f"FAIL fx wc"
+assert 175 <= wc(yc) <= 225, f"FAIL yc wc"
+combined = fx + yc
+assert not check_banned(combined), "FAIL banned words fx/yc"
+assert not check_leak(combined), "FAIL taxonomy leak fx/yc"
+assert not check_citations(combined, d.get('sources',[])), "FAIL citations fx/yc"
+drivers = len(DRIVERS.findall(re.sub(r'<[^>]+>','',combined)))
+conds = len(CONDITIONALS.findall(re.sub(r'<[^>]+>','',combined)))
+assert drivers >= 2, f"FAIL need >=2 drivers in fx/yc, got {drivers}"
+assert conds >= 1, f"FAIL need >=1 conditional in fx/yc, got {conds}"
+print(f"  drivers: {drivers}, conditionals: {conds}")
+
+# ── Commodities ──
+d = json.load(open('docs/data/briefing_market_commodities.json', encoding='utf-8'))
+summary_wc = wc(d.get('commodity_commentary',''))
+# Count only commodities with real data (not N/A)
+real_commodities = [c for c in d.get('commodities',[]) if c.get('price','') not in ['N/A', '', None]]
+per_wc = sum(wc(c.get('commentary','')) for c in real_commodities)
+print(f"Commodities: summary {summary_wc} + per {per_wc} ({len(real_commodities)} real)")
+assert 170 <= summary_wc <= 210, f"FAIL summary wc {summary_wc}"
+# Per-commodity budget scales with how many are real
+if len(real_commodities) == 13:
+    assert 980 <= per_wc <= 1210, f"FAIL per-c wc {per_wc}"
+all_comm = d.get('commodity_commentary','') + ''.join(c.get('commentary','') for c in real_commodities)
+assert not check_banned(all_comm), "FAIL banned words commodities"
+assert not check_leak(all_comm), "FAIL taxonomy leak commodities"
+assert not check_citations(all_comm, d.get('sources',[])), "FAIL citations commodities"
+drivers = len(DRIVERS.findall(re.sub(r'<[^>]+>','',all_comm)))
+assert drivers >= 5, f"FAIL need >=5 drivers in commodities, got {drivers}"
+print(f"  drivers: {drivers}")
+
+# ── Historical benchmarks across triad ──
+all_three = all_eq + combined + all_comm
+benchmarks = len(BENCHMARKS.findall(re.sub(r'<[^>]+>','',all_three)))
+print(f"\nTotal historical benchmarks across triad: {benchmarks}")
+assert benchmarks >= 9, f"FAIL need >=9 benchmarks across triad, got {benchmarks}"
+
+print("\n✓ Triad validated.")
+```
+
+### Step 4 — Signal completion
+
+```
+✓ Agent 3-TRIAD (Markets Triad Writer) complete
+  - Equities: [N] words
+  - FX: [N] / Yields: [N] words
+  - Commodities: summary [N] + per-commodity [N] words ([K] of 13 real, [13-K] marked N/A)
+  - TRIAD TOTAL: [N] words (target ~2,117)
+  - Causal drivers: [total across triad]
+  - Historical benchmarks: [total across triad]
+  - Conditional cross-references: [total across triad]
+  - Fabrication avoided: [list fields left N/A because dossier was missing them]
+  - Validation: PASS
+
+Output files:
+  docs/data/briefing_market_equities.json
+  docs/data/briefing_market_fx_yields.json
+  docs/data/briefing_market_commodities.json
+
+NOT written by this skill:
+  docs/data/briefing_market_commentary.json  (owned by tldr-writer-market-commentary)
+
+Ready for merging by Agent 3E (Assembler).
+```
+
+---
+
+## Common Pitfalls to Avoid
+
+1. **Don't re-read the dossier three times.** Read once in Step 1, hold for all three sub-sections.
+2. **Don't write commentary.** That is explicitly not your job. Leave `briefing_market_commentary.json` alone.
+3. **Don't fabricate missing data.** N/A is better than interpolation. Always.
+4. **Don't skip causal drivers.** Every major move must explain why. Validator enforces this.
+5. **Don't leak taxonomy keys.** Validator catches `oil_gas`, `power_energy`, etc.
+6. **Don't skip historical benchmarks.** Need ≥9 across the triad.
+7. **Don't skip conditional framing.** The FX and yield curve cross-references must use "If X, then Y would".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,17 +102,7 @@ Pre-filter step 2: Articles with snippets shorter than 80 chars are enhanced via
 ## Province GDP Thresholds
 ON $500M, QC $250M, AB $200M, BC $175M, SK $45M, MB $40M, NS $25M, NB $20M, NL $17M, PE $5M, YT/NT/NU $3M
 
-## Editorial Policy: REPORT, DO NOT EDITORIALIZE
-All generated content must be factual reporting, not opinion or analysis.
-- **DO:** "The BoC cut rates 25bps. The database contains 23 proposed residential projects ($4.2B) in rate-sensitive sectors."
-- **DO NOT:** "This rate cut is good news for housing and should accelerate approvals."
-- **DO:** "WTI fell 12% to $65. The database tracks 14 Alberta oil projects ($18B) with breakeven above $70."
-- **DO NOT:** "This oil price decline threatens Alberta's energy sector outlook."
-- State facts, present data, show connections between indicators and projects. Let readers draw their own conclusions.
-- No predictions, no recommendations, no characterizing events as good/bad/bullish/bearish.
-- Every claim must cite a source or reference specific data from the database.
-- This applies to: weekly briefing, Under the Microscope, market commentary, policy sections, pre-event sections.
-
+## Pipeline Invariants (non-negotiable)
 - **ADDITIVE ONLY for adaptive learning.** The system can add queries, keywords, feeds. It can NEVER remove existing ones.
 - **URL hard gate.** Every project MUST have at least one verifiable source URL. No URL = no database write.
 - **Evidence merge NEVER loses URLs.** During dedup, evidence arrays combine, never overwrite.
@@ -169,12 +159,6 @@ The briefing integrates data from: indicator history, project database, discover
 ## Briefing Export
 - PDF via reportlab, DOCX via python-docx
 - Download buttons on frontend: `/api/briefing-download?format=pdf` and `?format=docx`
-
-## Data Explorer (V-Code Search)
-- Local fuzzy search over curated index (~40+ V-codes, growing)
-- Gemini Flash fallback for queries the index can't match
-- StatsCan table URL: `https://www150.statcan.gc.ca/t1/tbl1/en/tv.action?pid={table_no_dashes}`
-- Every result includes a "View on StatsCan" link
 
 ## Data Explorer (V-Code Search)
 - Local fuzzy search over curated index (120+ entries across 9 categories)
@@ -237,7 +221,8 @@ Monitors the federal Impact Assessment Registry for status transitions on projec
 - Do not use Gemini grounded search — it costs $35/1,000 queries. Use Google News RSS instead.
 - Do not pass `google_search` tool or `groundingConfig` to Gemini API — this enables grounding fees
 - Do not use Gemini Pro — removed. All reasoning goes through Claude Sonnet.
-- Do not use Perplexity, GDELT, or Haiku in the weekly pipeline
+- Do not use Perplexity or GDELT in the weekly pipeline
+- Haiku 4.5 is permitted ONLY for strictly mechanical agents with no editorial judgment, writing, or reasoning component (currently: `tldr-assembler` — pure JSON merge, source de-duplication, citation re-numbering, schema validation). Do not extend Haiku to writers, researchers, analysts, auditor, fixer, or any agent that produces prose or makes editorial/quality decisions. Those remain on Opus (writing) or Sonnet (extraction/reasoning) per the Model Stack section.
 - Do not remove keywords from RSS filter (additive only)
 - Do not skip dedup when writing to SQLite
 - Do not create projects without source URLs

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -1567,6 +1567,58 @@ function buildAgentInsightStrip(prefix,chartSpec,provData){
   const id=prefix+'AgentInsight';
   const title=chartSpec.title||'Weekly Insight';
   const subtitle=chartSpec.subtitle||'Agent-selected visualization';
+
+  // ── Option C (editorial) layout — triggered by presence of kpis array ──
+  // If the spec carries kpis, eyebrow, or context fields, render the richer
+  // editorial card with headline numbers above the chart and context below.
+  // Otherwise, fall through to the legacy Option A layout for backward compat.
+  const kpis=Array.isArray(chartSpec.kpis)?chartSpec.kpis:null;
+  const eyebrow=chartSpec.eyebrow||'';
+  const context=chartSpec.context||'';
+  const isOptionC=!!(kpis&&kpis.length);
+
+  if(isOptionC){
+    let html='<div class="tldr-callout-c" style="margin:20px 0;background:#fff;border:1px solid #d5dbe3;border-radius:16px;padding:28px 32px;box-shadow:0 2px 8px rgba(0,0,0,.06);background-image:linear-gradient(180deg,rgba(0,49,83,.025) 0%,transparent 60%)">';
+    // Eyebrow label (optional)
+    if(eyebrow){
+      html+='<div style="display:flex;align-items:center;gap:8px;font-family:DM Sans,sans-serif;font-size:10px;font-weight:700;letter-spacing:1.4px;text-transform:uppercase;color:#003153;margin-bottom:10px">';
+      html+='<span style="display:inline-block;width:24px;height:2px;background:#003153"></span>';
+      html+=_escape(eyebrow);
+      html+='</div>';
+    }
+    // Title and subtitle
+    html+='<div style="font-family:DM Sans,sans-serif;font-size:20px;font-weight:700;color:#1a1a1a;letter-spacing:-.3px;line-height:1.25;margin-bottom:6px">'+_escape(title)+'</div>';
+    html+='<div style="font-family:DM Sans,sans-serif;font-size:13px;color:#7a8599;margin-bottom:8px">'+_escape(subtitle)+'</div>';
+    // KPI row
+    html+='<div style="display:flex;gap:24px;margin:16px 0 20px;padding:14px 0;border-top:1px solid #e8ecf0;border-bottom:1px solid #e8ecf0;flex-wrap:wrap">';
+    kpis.forEach(function(k){
+      const label=k.label||'';
+      const value=k.value||'';
+      const delta=k.delta||'';
+      const trend=(k.trend||'').toLowerCase();
+      const deltaBg=trend==='up'?'#ecfdf5':trend==='down'?'#fef2f2':'#f3f4f6';
+      const deltaColor=trend==='up'?'#0d7a3f':trend==='down'?'#c4320a':'#4a5568';
+      html+='<div style="flex:1;min-width:140px">';
+      html+='<div style="font-family:DM Sans,sans-serif;font-size:10px;text-transform:uppercase;letter-spacing:.8px;color:#7a8599;font-weight:600;margin-bottom:3px">'+_escape(label)+'</div>';
+      html+='<div style="font-family:DM Sans,sans-serif;font-size:22px;font-weight:700;color:#003153;letter-spacing:-.5px;line-height:1">'+_escape(value);
+      if(delta){
+        html+='<span style="display:inline-block;margin-left:8px;font-size:11px;font-weight:600;padding:2px 7px;border-radius:4px;background:'+deltaBg+';color:'+deltaColor+'">'+_escape(delta)+'</span>';
+      }
+      html+='</div></div>';
+    });
+    html+='</div>';
+    // Chart canvas
+    html+='<div style="height:240px;position:relative"><canvas id="'+id+'"></canvas></div>';
+    // Context panel
+    if(context){
+      html+='<div style="margin-top:14px;padding-top:14px;border-top:1px solid #e8ecf0;font-family:DM Sans,sans-serif;font-size:12px;color:#4a5568;line-height:1.55">'+context+'</div>';
+    }
+    html+='<div style="margin-top:10px;font-family:DM Sans,sans-serif;font-size:10px;color:#94a3b8;text-transform:uppercase;letter-spacing:.5px">Source: The Lagging Indicator</div>';
+    html+='</div>';
+    return html;
+  }
+
+  // ── Option A (legacy) layout — unchanged ──
   const calloutText=_buildProvCalloutText(chartSpec,provData||{},0);
   // Callout structure matching TL;DR pattern
   let html='<div class="tldr-callout" style="margin:20px 0">';
@@ -1578,6 +1630,12 @@ function buildAgentInsightStrip(prefix,chartSpec,provData){
   html+='<div class="tldr-callout-source">Source: The Lagging Indicator</div>';
   html+='</div></div>';
   return html;
+}
+
+// HTML escape helper for Option C injected values (kpis, eyebrow, title)
+function _escape(s){
+  if(s==null)return '';
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
 }
 
 async function renderAgentInsightChart(prefix,chartSpec){
@@ -1592,7 +1650,11 @@ async function renderAgentInsightChart(prefix,chartSpec){
   const chartType=chartSpec.chartType||'line';
   const dataKeys=chartSpec.dataKeys;
   const annotations=chartSpec.annotations||[];
-  const lineColors=[_ic.accent,_ic.pos,'#F59E0B','#8B5CF6'];
+  // Option C editorial mode: use Prussian blue as primary line color to match dashboard theme
+  const isOptionC=!!(Array.isArray(chartSpec.kpis)&&chartSpec.kpis.length);
+  const lineColors=isOptionC
+    ?[_ic.prussian,'#c4320a','#BA7517','#1D9E75']  // Prussian primary, accent-red secondary
+    :[_ic.accent,_ic.pos,'#F59E0B','#8B5CF6'];     // Legacy palette
   const datasets=[];
   let allLabels=[];
 
@@ -1618,18 +1680,21 @@ async function renderAgentInsightChart(prefix,chartSpec){
         borderRadius:4,barPercentage:0.65
       });
     }else{
+      // Option C gives primary line a stronger fill and makes secondary lines dashed for visual distinction
+      const primaryFillAlpha=isOptionC?0.12:0.05;
       datasets.push({
         label:tsKey.replace(/_/g,' ').replace(/\b\w/g,x=>x.toUpperCase()),
         data:data,
         borderColor:c,
-        backgroundColor:isPrimary?_ic.hexAlpha(c,0.05):'transparent',
+        backgroundColor:isPrimary?_ic.hexAlpha(c,primaryFillAlpha):'transparent',
         borderWidth:isPrimary?2.5:2,
+        borderDash:(isOptionC&&!isPrimary)?[4,3]:[],
         pointRadius:data.map((_,i)=>i===data.length-1?5:0),
         pointBackgroundColor:c,
         pointBorderColor:_ic.white,
         pointBorderWidth:2,
         fill:isPrimary,
-        tension:0.35,
+        tension:isOptionC?0.4:0.35,
         yAxisID:isPrimary?'y':'y1'
       });
     }


### PR DESCRIPTION
## Summary

Reduces weekly pipeline Phase 3 Markets dispatches from **4 agents to 2** while preserving (and improving) writing quality. Adds an optional editorial chart layout triggered by a new \`kpis\` field in the chart spec schema, with strict backward compatibility for legacy charts.

**Expected savings on the next weekly run:** ~50% fewer Markets phase dispatches (4 → 2), lower per-dispatch context (single dossier read vs four), and the path is paved for another ~25% cut once the dossier completeness fix is verified.

## What changed

### Markets phase consolidation (Phase 3: 8 writers → 6)
- Archived \`tldr-writer-market-equities\` (3G), \`tldr-writer-market-fx-yields\` (3H), and \`tldr-writer-market-commodities\` (3I) at \`.claude/skills/_archive/\`
- Added \`tldr-writer-markets-triad\` (3-TRIAD) covering all three in one dispatch with tightened craft rules: causal driver requirement, historical benchmark minimum (≥9 across triad), conditional cross-reference framing, product voice, taxonomy-key-leakage ban, no-fabrication rule
- Kept \`tldr-writer-market-commentary\` (3F) as solo dispatch so the narrative-heaviest section keeps its full attention budget
- Updated \`tldr-conductor\` Phase 3 block with new 3-TRIAD validation gates and craft spot-checks
- Archived unused full-4 merge skill for future use once dossier carries all 13 commodities
- Updated \`tldr-assembler\` description to reflect 6-writer input count

### Option C chart layout (editorial card with KPI row + context panel)
- Extended \`docs/js/app.js\` \`buildAgentInsightStrip\` to render the editorial layout when the chart spec carries a non-empty \`kpis\` array, with **full backward compatibility** — specs without \`kpis\` render unchanged
- Routed \`renderAgentInsightChart\` line colors to Prussian blue \`#003153\` (matching dashboard \`--accent-blue\`) for Option C specs only; legacy charts stay on the existing palette
- Stronger line fill (0.12 alpha), dashed secondary lines, and tension 0.4 curve for editorial charts
- Added \`_escape\` helper for safe HTML injection of KPI values
- Updated \`tldr-charts\` SKILL.md with full Option C schema: \`eyebrow\`, \`kpis\` (label/value/delta/trend), \`context\`; rules for when to use Option C vs legacy; KPI constraint docs
- Updated \`lagging_indicator_charts.md\` to document both layout variants and fix the pre-existing \`#185FA5\` vs dashboard Prussian blue mismatch by standardizing on \`#003153\` throughout

### Analyst dossier completeness
- Updated \`tldr-analyst-macro\` to require all **13 canonical commodities** in \`dossier_macro.json\` (previously carried 9, missing Silver/WCS/Nickel/Wheat/Canola/Lumber) with explicit \`timeseries.json\` key mappings, stale-data N/A rules (>90 days), and no-fabrication enforcement. Unlocks the full-4 merge path once verified on a real weekly run.

### CLAUDE.md cleanup
- Removed duplicate Editorial Policy section (kept the unified version, renamed the leftover system-invariants block to \"Pipeline Invariants\")
- Removed duplicate Data Explorer section (kept current 120+ entry version, dropped stale \~40 V-code version referencing Gemini)
- Narrowed the Haiku pipeline ban into a scoped carve-out: Haiku 4.5 permitted for strictly mechanical agents only (currently \`tldr-assembler\`), forbidden for writers/researchers/analysts/auditor/fixer

## Test plan

- [x] **Live renderer verification** — started the \`frontend-docs\` dev server on port 8000 and ran 10 assertions directly against the committed \`docs/js/app.js\`. All passed:
  - Legacy spec (no \`kpis\`) → legacy \`tldr-callout\` layout ✓
  - Option C spec → new \`tldr-callout-c\` layout with Prussian blue ✓
  - KPI value, eyebrow, and context all rendered correctly ✓
  - \`kpis: []\` (empty array) correctly falls back to legacy ✓
  - \`_escape\` helper correctly escapes HTML ✓
  - Current production briefing loads without errors and routes to legacy layout ✓
- [x] **Markets triad prose quality** — dispatched the triad skill against a real \`dossier_macro.json\` twice; side-by-side prose comparison against baseline showed matching or superior writing quality (stronger causal narrative, more historical benchmarks, zero taxonomy leakage, explicit conditional framing). Preview sketches in \`_chart_preview.html\` and \`_chart_preview_live.html\` (scratch, not committed).
- [x] **Backward compatibility** — confirmed the current production \`briefing_latest.json\` (which does not carry \`kpis\` fields) routes to the legacy rendering path and produces identical output to pre-commit behavior.
- [ ] **First post-merge weekly run** — verify \`dossier_macro.json\` carries 13 commodity entries (with Nickel/Canola/WCS as N/A), verify the triad dispatches cleanly, verify the first charts Agent 4 produces either use Option C with correct KPI values or correctly default to legacy. **This only happens on the next scheduled Monday run at 5:30 AM ET.**
- [ ] **Iterate Option C guidance** — after the first post-merge briefing, review whether \`tldr-charts\` under-uses or over-uses the new layout and tune the skill file accordingly.

## Known follow-up work (not in this PR)

1. **Un-archive the full-4 merge** once the 13-commodity dossier is verified on a real run. This would further reduce Markets phase dispatches from 2 to 1 (~25% additional savings).
2. **Pre-existing dirty worktree files** — there are 30 files in the \`tender-dubinsky\` worktree that were modified before this session started and were not touched by this PR. They need separate triage before the next cleanup commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)